### PR TITLE
Adding oops.Request and oops.Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,14 @@ err8 := oops.
     Tenant(workspaceID, "name", "my little project").
     Errorf("could not fetch user")
 
-// with error wrapping
+// with optional http request and response
 err9 := oops.
+    Request(req, false).
+    Response(res, true).
+    Errorf("could not fetch user")
+
+// with error wrapping
+err10 := oops.
     In("repository").
     Tags("database", "sql").
     User(userID).
@@ -227,7 +233,7 @@ err9 := oops.
     Wrapf(sql.Exec(query), "could not fetch user")  // Wrapf returns nil when sql.Exec() is nil
 
 // with panic recovery
-err10 := oops.
+err11 := oops.
     In("repository").
     Tags("database", "sql").
     Recover(func () {
@@ -235,7 +241,7 @@ err10 := oops.
     })
 
 // with assertion
-err11 := oops.
+err12 := oops.
     In("repository").
     Tags("database", "sql").
     Recover(func () {
@@ -267,21 +273,23 @@ The library provides an error builder. Each method can be used standalone (eg: `
 
 The `oops.OopsError` builder must finish with either `.Errorf(...)`, `.Wrap(...)` or `.Wrapf(...)`.
 
-| Builder method             | Getter                                  | Description                                                                                                                                                                                |
-| -------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.With(string, any)`       | `err.Context() map[string]any`          | Supply a list of attributes key+value                                                                                                                                                      |
-| `.Code(string)`            | `err.Code() string`                     | Set a code or slug that describes the error. Error messages are intented to be read by humans, but such code is expected to be read by machines and be transported over different services |
-| `.Time(time.Time)`         | `err.Time() time.Time`                  | Set the error time (default: `time.Now()`)                                                                                                                                                 |
-| `.Since(time.Time)`        | `err.Duration() time.Duration`          | Set the error duration                                                                                                                                                                     |
-| `.Duration(time.Duration)` | `err.Duration() time.Duration`          | Set the error duration                                                                                                                                                                     |
-| `.In(string)`              | `err.Domain() string`                   | Set the feature category or domain                                                                                                                                                         |
-| `.Tags(...string)`         | `err.Tags() []string`                   | Add multiple tags, describing the feature returning an error                                                                                                                               |
-| `.Trace(string)`           | `err.Trace() string`                    | Add a transaction id, trace id, correlation id... (default: ULID)                                                                                                                          |
-| `.Span(string)`            | `err.Span() string`                     | Add a span representing a unit of work or operation... (default: ULID)                                                                                                                     |
-| `.Hint(string)`            | `err.Hint() string`                     | Set a hint for faster debugging                                                                                                                                                            |
-| `.Owner(string)`           | `err.Owner() (string)`                  | Set the name/email of the collegue/team responsible for handling this error. Useful for alerting purpose                                                                                   |
-| `.User(string, any...)`    | `err.User() (string, map[string]any)`   | Supply user id and a chain of key/value                                                                                                                                                    |
-| `.Tenant(string, any...)`  | `err.Tenant() (string, map[string]any)` | Supply tenant id and a chain of key/value                                                                                                                                                  |
+| Builder method                    | Getter                                  | Description                                                                                                                                                                                |
+| --------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.With(string, any)`              | `err.Context() map[string]any`          | Supply a list of attributes key+value                                                                                                                                                      |
+| `.Code(string)`                   | `err.Code() string`                     | Set a code or slug that describes the error. Error messages are intented to be read by humans, but such code is expected to be read by machines and be transported over different services |
+| `.Time(time.Time)`                | `err.Time() time.Time`                  | Set the error time (default: `time.Now()`)                                                                                                                                                 |
+| `.Since(time.Time)`               | `err.Duration() time.Duration`          | Set the error duration                                                                                                                                                                     |
+| `.Duration(time.Duration)`        | `err.Duration() time.Duration`          | Set the error duration                                                                                                                                                                     |
+| `.In(string)`                     | `err.Domain() string`                   | Set the feature category or domain                                                                                                                                                         |
+| `.Tags(...string)`                | `err.Tags() []string`                   | Add multiple tags, describing the feature returning an error                                                                                                                               |
+| `.Trace(string)`                  | `err.Trace() string`                    | Add a transaction id, trace id, correlation id... (default: ULID)                                                                                                                          |
+| `.Span(string)`                   | `err.Span() string`                     | Add a span representing a unit of work or operation... (default: ULID)                                                                                                                     |
+| `.Hint(string)`                   | `err.Hint() string`                     | Set a hint for faster debugging                                                                                                                                                            |
+| `.Owner(string)`                  | `err.Owner() (string)`                  | Set the name/email of the collegue/team responsible for handling this error. Useful for alerting purpose                                                                                   |
+| `.User(string, any...)`           | `err.User() (string, map[string]any)`   | Supply user id and a chain of key/value                                                                                                                                                    |
+| `.Tenant(string, any...)`         | `err.Tenant() (string, map[string]any)` | Supply tenant id and a chain of key/value                                                                                                                                                  |
+| `.Request(*http.Request, bool)`   | `err.Request() *http.Request`           | Supply http request                                                                                                                                                                        |
+| `.Response(*http.Response, bool)` | `err.Response() *http.Response`         | Supply http response                                                                                                                                                                       |
 
 ### Other helpers
 
@@ -374,7 +382,7 @@ func handlePanic() error {
 
 ### Assertions
 
-Assertions may be considered an anti-pattern for Golang, since we only call `panic()` for unexpected and critical errors. In this situation, assertions might help developers to write safer code.
+Assertions may be considered an anti-pattern for Golang since we only call `panic()` for unexpected and critical errors. In this situation, assertions might help developers to write safer code.
 
 ```go
 func mayPanic() {
@@ -483,7 +491,7 @@ Examples of formatters can be found in `ToMap()`, `Format()`, `Marshal()` and `L
 
 ### Wrap/Wrapf shortcut
 
-`oops.Wrap(...)` and `oops.Wrapf(...)` return nil if the provided `error` is nil.
+`oops.Wrap(...)` and `oops.Wrapf(...)` returns nil if the provided `error` is nil.
 
 ❌ So don't write:
 

--- a/builder.go
+++ b/builder.go
@@ -2,6 +2,7 @@ package oops
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -56,6 +57,10 @@ func new() OopsErrorBuilder {
 		tenantID:   "",
 		tenantData: map[string]any{},
 
+		// http
+		req: nil,
+		res: nil,
+
 		// stacktrace
 		stacktrace: nil,
 	}
@@ -83,6 +88,9 @@ func (o OopsErrorBuilder) copy() OopsErrorBuilder {
 		userData:   lo.Assign(map[string]any{}, o.userData),
 		tenantID:   o.tenantID,
 		tenantData: lo.Assign(map[string]any{}, o.tenantData),
+
+		req: o.req,
+		res: o.res,
 
 		// stacktrace: o.stacktrace,
 	}
@@ -302,5 +310,19 @@ func (o OopsErrorBuilder) Tenant(tenantID string, tenantData ...any) OopsErrorBu
 		}
 	}
 
+	return o2
+}
+
+// Request supplies a http.Request.
+func (o OopsErrorBuilder) Request(req *http.Request, withBody bool) OopsErrorBuilder {
+	o2 := o.copy()
+	o2.req = lo.ToPtr(lo.T2(req, withBody))
+	return o2
+}
+
+// Response supplies a http.Response.
+func (o OopsErrorBuilder) Response(res *http.Response, withBody bool) OopsErrorBuilder {
+	o2 := o.copy()
+	o2.res = lo.ToPtr(lo.T2(res, withBody))
 	return o2
 }

--- a/examples/slog/example.go
+++ b/examples/slog/example.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/samber/oops"
@@ -12,6 +14,8 @@ import (
 // go run examples/slog/example.go | jq .error.stacktrace -r
 
 func d() error {
+	req, _ := http.NewRequest("POST", "http://localhost:1337/foobar", strings.NewReader("hello world"))
+
 	return oops.
 		Code("iam_authz_missing_permission").
 		In("authz").
@@ -20,6 +24,7 @@ func d() error {
 		With("permission", "post.create").
 		Hint("Runbook: https://doc.acme.org/doc/abcd.md").
 		User("user-123", "firstname", "john", "lastname", "doe").
+		Request(req, true).
 		Errorf("permission denied")
 }
 

--- a/oops.go
+++ b/oops.go
@@ -1,6 +1,9 @@
 package oops
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 // Wrap wraps an error into an `oops.OopsError` object that satisfies `error`
 func Wrap(err error) error {
@@ -116,4 +119,14 @@ func User(userID string, data map[string]any) OopsErrorBuilder {
 // Tenant supplies tenant id and a chain of key/value.
 func Tenant(tenantID string, data map[string]any) OopsErrorBuilder {
 	return new().Tenant(tenantID, data)
+}
+
+// Request supplies a http.Request.
+func Request(req *http.Request, withBody bool) OopsErrorBuilder {
+	return new().Request(req, withBody)
+}
+
+// Response supplies a http.Response.
+func Response(res *http.Response, withBody bool) OopsErrorBuilder {
+	return new().Response(res, withBody)
 }


### PR DESCRIPTION
Closes #4 

Hey @antonsergeyev, I just added 2 helpers:

- `oops.Request(req *http.Request, withBody bool)`
- `oops.Response(req *http.Response, withBody bool)`

Both are dumped using the `httputil` package. Thanks for the suggestion 👌 
