### PR TITLE
Only skip GOROOT frames when GOROOT is non-empty.

### DIFF
--- a/error.go
+++ b/error.go
@@ -625,7 +625,7 @@ func (o *OopsError) formatVerbose() string {
 	if stacktrace := o.Stacktrace(); stacktrace != "" {
 		lines := strings.Split(stacktrace, "\n")
 		stacktrace = "  " + strings.Join(lines, "\n  ")
-		output += fmt.Sprintf("Stackstrace:\n%s\n", stacktrace)
+		output += fmt.Sprintf("Stacktrace:\n%s\n", stacktrace)
 	}
 
 	if sources := o.Sources(); sources != "" && !SourceFragmentsHidden {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -101,10 +101,10 @@ func newStacktrace(span string) *oopsStacktrace {
 		}
 		function := shortFuncName(f)
 
-		isGoPkg := strings.Contains(file, runtime.GOROOT())         // skip frames in GOROOT
-		isOopsPkg := strings.Contains(file, packageName)            // skip frames in this package
-		isExamplePkg := strings.Contains(file, packageNameExamples) // do not skip frames in this package examples
-		isTestPkg := strings.Contains(file, "_test.go")             // do not skip frames in tests
+		isGoPkg := len(runtime.GOROOT()) > 0 && strings.Contains(file, runtime.GOROOT()) // skip frames in GOROOT if it's set
+		isOopsPkg := strings.Contains(file, packageName)                                 // skip frames in this package
+		isExamplePkg := strings.Contains(file, packageNameExamples)                      // do not skip frames in this package examples
+		isTestPkg := strings.Contains(file, "_test.go")                                  // do not skip frames in tests
 
 		if !isGoPkg && (!isOopsPkg || isExamplePkg || isTestPkg) {
 			frames = append(frames, oopsStacktraceFrame{


### PR DESCRIPTION
This fixes an issue I observed when running my compiled application and attempting to see a stack trace. The traces were always empty when running the precompiled binary, even though they worked fine when using `go run`. After some debugging, I discovered that due to the `-trimpath` argument I was using when building, the `runtime.GOROOT()` was returning an empty string. Therefore, every stack frame was being omitted.

Also a small typo fix 🙂 