### PR TITLE
fix: change User and Tenant param type to ...any

### DIFF
--- a/oops.go
+++ b/oops.go
@@ -128,12 +128,12 @@ func Owner(owner string) OopsErrorBuilder {
 }
 
 // User supplies user id and a chain of key/value.
-func User(userID string, data map[string]any) OopsErrorBuilder {
+func User(userID string, data ...any) OopsErrorBuilder {
 	return new().User(userID, data)
 }
 
 // Tenant supplies tenant id and a chain of key/value.
-func Tenant(tenantID string, data map[string]any) OopsErrorBuilder {
+func Tenant(tenantID string, data ...any) OopsErrorBuilder {
 	return new().Tenant(tenantID, data)
 }
 


### PR DESCRIPTION
Hey 👋,

`oops.User()` only accept `map[string]any` as second argument but the underlying function is expecting `...any` (chain of key/value)

This is the same for `oops.Tenant()`

This result in this code working
```golang
oops.Hint("test").User("userID", "firstname", "John")
```
But this code does not
```golang
// Too many arguments in call to 'oops.User'
oops.User("userID", "firstname", "John")
// Is accepted but doesn't add firstname to user
oops.User("userID", map[string]any{
	"firstname": "John"
})
```