### PR TITLE
Add StackFrames method for sentry compat

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -83,6 +83,24 @@ func (st *oopsStacktrace) Source() (string, []string) {
 	return header, body
 }
 
+func (st *oopsStacktrace) StackFrames() []runtime.Frame {
+	if len(st.frames) == 0 {
+		return nil
+	}
+
+	frames := make([]runtime.Frame, len(st.frames))
+	for i, frame := range st.frames {
+		frames[i] = runtime.Frame{
+			PC:   frame.pc,
+			File: frame.file,
+			Line: frame.line,
+			Function: frame.function,
+		}
+	}
+
+	return frames
+}
+
 func newStacktrace(span string) *oopsStacktrace {
 	frames := []oopsStacktraceFrame{}
 


### PR DESCRIPTION
Adds StackFrames method which converts stacks to runtime.frame to be compatible with sentry-go https://github.com/getsentry/sentry-go/blob/master/stacktrace.go#L75