### PR TITLE
Implement the slog.LogValuer interface

### DIFF
--- a/error.go
+++ b/error.go
@@ -20,7 +20,10 @@ var (
 	Local                 *time.Location = time.UTC
 )
 
-var _ error = (*OopsError)(nil)
+var (
+	_ error          = (*OopsError)(nil)
+	_ slog.LogValuer = (*OopsError)(nil)
+)
 
 type OopsError struct {
 	err      error
@@ -365,8 +368,8 @@ func (o OopsError) Sources() string {
 	)
 }
 
-// LogValuer returns a slog.Value for logging.
-func (o OopsError) LogValuer() slog.Value {
+// LogValue returns a slog.Value for logging.
+func (o OopsError) LogValue() slog.Value {
 	attrs := []slog.Attr{slog.String("message", o.msg)}
 
 	if err := o.Error(); err != "" {

--- a/error.go
+++ b/error.go
@@ -368,6 +368,13 @@ func (o OopsError) Sources() string {
 	)
 }
 
+// LogValuer returns a slog.Value for logging.
+//
+// Deprecated: Use LogValue instead.
+func (o OopsError) LogValuer() slog.Value {
+	return o.LogValue()
+}
+
 // LogValue returns a slog.Value for logging.
 func (o OopsError) LogValue() slog.Value {
 	attrs := []slog.Attr{slog.String("message", o.msg)}

--- a/oops_test.go
+++ b/oops_test.go
@@ -535,7 +535,7 @@ func TestOopsMixedWithGetters(t *testing.T) {
 	is.Equal(err.(OopsError).Unwrap().(OopsError).msg, "a message 42")
 }
 
-func TestOopsLogValuer(t *testing.T) {
+func TestOopsLogValue(t *testing.T) {
 	is := assert.New(t)
 
 	now := time.Now()
@@ -559,7 +559,7 @@ func TestOopsLogValuer(t *testing.T) {
 
 	is.Error(err)
 
-	got := err.(OopsError).LogValuer().Group()
+	got := err.(OopsError).LogValue().Group()
 	expectedAttrs := []slog.Attr{
 		slog.String("message", "a message 42"),
 		slog.String("err", "a message 42: assert.AnError general error for testing"),


### PR DESCRIPTION
When going through some logging inconsistencies locally I noticed that `oops` doesn't actually implement the `LogValuer` interface. Instead `slog` uses `json.Marshal` when logging (if you're logging as `json`).

The interface is defined as follows:
```
type LogValuer interface {
	LogValue() [Value](https://pkg.go.dev/log/slog#Value)
}
```

However, the implementation in `oops` is
```
func (o OopsError) LogValuer() slog.Value {
...
}
```

That is, the function is called `LogValuer` not `LogValue`!

This PR fixes this and also adds `_ slog.LogValuer = (*OopsError)(nil)` for clarity as well.