### PR TITLE
refactor(tests): migrate to table-driven test pattern

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -9,72 +9,137 @@ import (
 )
 
 func TestErrorsIs(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	err := Errorf("Error: %w", fs.ErrExist)
-	is.ErrorIs(err, fs.ErrExist)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "Errorf",
+			run: func(is *assert.Assertions) {
+				err := Errorf("Error: %w", fs.ErrExist)
+				is.ErrorIs(err, fs.ErrExist)
+			},
+		},
+		{
+			name: "Wrap",
+			run: func(is *assert.Assertions) {
+				err := Wrap(fs.ErrExist)
+				is.ErrorIs(err, fs.ErrExist)
+			},
+		},
+		{
+			name: "Wrap_reflexive",
+			run: func(is *assert.Assertions) {
+				err := Wrap(fs.ErrExist)
+				is.ErrorIs(err, err) //nolint:testifylint
+			},
+		},
+		{
+			name: "Wrapf",
+			run: func(is *assert.Assertions) {
+				err := Wrapf(fs.ErrExist, "Error: %w", assert.AnError)
+				is.ErrorIs(err, fs.ErrExist)
+			},
+		},
+		{
+			name: "Join_first",
+			run: func(is *assert.Assertions) {
+				err := Join(fs.ErrExist, assert.AnError)
+				is.ErrorIs(err, fs.ErrExist)
+			},
+		},
+		{
+			name: "Join_second",
+			run: func(is *assert.Assertions) {
+				err := Join(assert.AnError, fs.ErrExist)
+				is.ErrorIs(err, fs.ErrExist)
+			},
+		},
+		{
+			name: "Recover",
+			run: func(is *assert.Assertions) {
+				err := Recover(func() { panic(fs.ErrExist) })
+				is.ErrorIs(err, fs.ErrExist)
+			},
+		},
+		{
+			name: "Recoverf",
+			run: func(is *assert.Assertions) {
+				err := Recoverf(func() { panic(fs.ErrExist) }, "Error: %w", assert.AnError)
+				is.ErrorIs(err, fs.ErrExist)
+			},
+		},
+		{
+			// Two independently created OopsErrors must not match each other.
+			// Previously, Is() returned true for any OopsError target regardless of identity.
+			name: "distinct_oops_errors_not_equal",
+			run: func(is *assert.Assertions) {
+				err1 := Errorf("error 1")
+				err2 := Errorf("error 2")
+				is.False(errors.Is(err1, err2)) //nolint:testifylint
+				is.False(errors.Is(err2, err1)) //nolint:testifylint
+			},
+		},
+	}
 
-	err = Wrap(fs.ErrExist)
-	is.ErrorIs(err, fs.ErrExist)
-
-	err = Wrap(fs.ErrExist)
-	is.ErrorIs(err, err) //nolint:testifylint
-
-	err = Wrapf(fs.ErrExist, "Error: %w", assert.AnError)
-	is.ErrorIs(err, fs.ErrExist)
-
-	err = Join(fs.ErrExist, assert.AnError)
-	is.ErrorIs(err, fs.ErrExist)
-	err = Join(assert.AnError, fs.ErrExist)
-	is.ErrorIs(err, fs.ErrExist)
-
-	err = Recover(func() {
-		panic(fs.ErrExist)
-	})
-	is.ErrorIs(err, fs.ErrExist)
-
-	err = Recoverf(func() {
-		panic(fs.ErrExist)
-	}, "Error: %w", assert.AnError)
-	is.ErrorIs(err, fs.ErrExist)
-
-	// Two independently created OopsErrors must not match each other.
-	// Previously, Is() returned true for any OopsError target regardless of identity.
-	err1 := Errorf("error 1")
-	err2 := Errorf("error 2")
-	is.False(errors.Is(err1, err2)) //nolint:testifylint
-	is.False(errors.Is(err2, err1)) //nolint:testifylint
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestErrorsAs(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
 	var anError error = &fs.PathError{Err: fs.ErrExist}
-	var target *fs.PathError
 
-	err := Errorf("Error: %w", anError)
-	is.ErrorAs(err, &target)
+	tests := []struct {
+		name  string
+		errFn func() error
+	}{
+		{
+			name:  "Errorf",
+			errFn: func() error { return Errorf("Error: %w", anError) },
+		},
+		{
+			name:  "Wrap",
+			errFn: func() error { return Wrap(anError) },
+		},
+		{
+			name:  "Wrapf",
+			errFn: func() error { return Wrapf(anError, "Error: %w", assert.AnError) },
+		},
+		{
+			name:  "Join_first",
+			errFn: func() error { return Join(anError, assert.AnError) },
+		},
+		{
+			name:  "Join_second",
+			errFn: func() error { return Join(assert.AnError, anError) },
+		},
+		{
+			name:  "Recover",
+			errFn: func() error { return Recover(func() { panic(anError) }) },
+		},
+		{
+			name:  "Recoverf",
+			errFn: func() error { return Recoverf(func() { panic(anError) }, "Error: %w", assert.AnError) },
+		},
+	}
 
-	err = Wrap(anError)
-	is.ErrorAs(err, &target)
-
-	err = Wrapf(anError, "Error: %w", assert.AnError)
-	is.ErrorAs(err, &target)
-
-	err = Join(anError, assert.AnError)
-	is.ErrorAs(err, &target)
-	err = Join(assert.AnError, anError)
-	is.ErrorAs(err, &target)
-
-	err = Recover(func() {
-		panic(anError)
-	})
-	is.ErrorAs(err, &target)
-
-	err = Recoverf(func() {
-		panic(anError)
-	}, "Error: %w", assert.AnError)
-	is.ErrorAs(err, &target)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			var target *fs.PathError
+			is.ErrorAs(tt.errFn(), &target)
+		})
+	}
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,6 +1,5 @@
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -11,8 +10,6 @@ github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -29,6 +26,7 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -66,7 +64,6 @@ golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
 golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -12,59 +12,115 @@ import (
 
 func TestAsOops(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	// OopsError is found
-	err := In("test").With("key", "value").Errorf("oops error")
-	oopsErr, ok := AsOops(err)
-	is.True(ok)
-	is.Equal("test", oopsErr.Domain())
-	is.Equal(map[string]any{"key": "value"}, oopsErr.Context())
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "oops_error_found",
+			run: func(is *assert.Assertions) {
+				err := In("test").With("key", "value").Errorf("oops error")
+				oopsErr, ok := AsOops(err)
+				is.True(ok)
+				is.Equal("test", oopsErr.Domain())
+				is.Equal(map[string]any{"key": "value"}, oopsErr.Context())
+			},
+		},
+		{
+			name: "non_oops_returns_false",
+			run: func(is *assert.Assertions) {
+				_, ok := AsOops(errors.New("plain error"))
+				is.False(ok)
+			},
+		},
+		{
+			name: "nil_returns_false",
+			run: func(is *assert.Assertions) {
+				_, ok := AsOops(nil)
+				is.False(ok)
+			},
+		},
+		{
+			name: "wrapped_oops_found",
+			run: func(is *assert.Assertions) {
+				err := In("test").With("key", "value").Errorf("oops error")
+				wrapped := fmt.Errorf("wrapper: %w", err)
+				oopsErr, ok := AsOops(wrapped)
+				is.True(ok)
+				is.Equal("test", oopsErr.Domain())
+			},
+		},
+		{
+			name: "deeply_nested_oops_found",
+			run: func(is *assert.Assertions) {
+				err := In("test").With("key", "value").Errorf("oops error")
+				deepWrapped := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", err))
+				oopsErr, ok := AsOops(deepWrapped)
+				is.True(ok)
+				is.Equal("test", oopsErr.Domain())
+			},
+		},
+	}
 
-	// Non-oops error returns false
-	plainErr := errors.New("plain error")
-	_, ok = AsOops(plainErr)
-	is.False(ok)
-
-	// Nil error returns false
-	_, ok = AsOops(nil)
-	is.False(ok)
-
-	// OopsError wrapped by fmt.Errorf is found
-	wrapped := fmt.Errorf("wrapper: %w", err)
-	oopsErr, ok = AsOops(wrapped)
-	is.True(ok)
-	is.Equal("test", oopsErr.Domain())
-
-	// Deeply nested OopsError is found
-	deepWrapped := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", err))
-	oopsErr, ok = AsOops(deepWrapped)
-	is.True(ok)
-	is.Equal("test", oopsErr.Domain())
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestAsError(t *testing.T) {
 	t.Parallel()
-	is := assert.New(t)
 
-	// Matches concrete error type
-	err := Wrapf(fs.ErrExist, "wrapped")
-	fsErr, ok := AsError[*fs.PathError](fmt.Errorf("path: %w", &fs.PathError{Op: "open", Path: "/tmp", Err: fs.ErrExist}))
-	is.True(ok)
-	is.Equal("open", fsErr.Op)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "matches_concrete_type",
+			run: func(is *assert.Assertions) {
+				fsErr, ok := AsError[*fs.PathError](fmt.Errorf("path: %w", &fs.PathError{Op: "open", Path: "/tmp", Err: fs.ErrExist}))
+				is.True(ok)
+				is.Equal("open", fsErr.Op)
+			},
+		},
+		{
+			name: "oops_via_AsError",
+			run: func(is *assert.Assertions) {
+				err := Wrapf(fs.ErrExist, "wrapped")
+				oopsErr, ok := AsError[OopsError](err)
+				is.True(ok)
+				is.NotEmpty(oopsErr.Span())
+			},
+		},
+		{
+			name: "non_matching_returns_false",
+			run: func(is *assert.Assertions) {
+				_, ok := AsError[*fs.PathError](errors.New("not a path error"))
+				is.False(ok)
+			},
+		},
+		{
+			name: "nil_returns_false",
+			run: func(is *assert.Assertions) {
+				_, ok := AsError[OopsError](nil)
+				is.False(ok)
+			},
+		},
+	}
 
-	// OopsError matched via AsError
-	oopsErr, ok := AsError[OopsError](err)
-	is.True(ok)
-	is.NotEmpty(oopsErr.Span())
-
-	// Non-matching type returns false
-	_, ok = AsError[*fs.PathError](errors.New("not a path error"))
-	is.False(ok)
-
-	// Nil error returns false
-	_, ok = AsError[OopsError](nil)
-	is.False(ok)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 // https://github.com/samber/oops/issues/95

--- a/kv.go
+++ b/kv.go
@@ -42,7 +42,7 @@ func dereferencePointers(data map[string]any) map[string]any {
 			continue // not a pointer, skip
 		}
 		val := reflect.ValueOf(value)
-		if val.Kind() == reflect.Ptr {
+		if val.Kind() == reflect.Pointer {
 			data[key] = dereferencePointerRecursive(val, 0)
 		}
 	}
@@ -80,7 +80,7 @@ func dereferencePointerRecursive(val reflect.Value, depth int) (ret any) {
 	if !val.IsValid() {
 		return nil
 	}
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Pointer {
 		return val.Interface()
 	}
 
@@ -99,7 +99,7 @@ func dereferencePointerRecursive(val reflect.Value, depth int) (ret any) {
 	}
 
 	// Recursively handle nested pointers
-	if elem.Kind() == reflect.Ptr {
+	if elem.Kind() == reflect.Pointer {
 		return dereferencePointerRecursive(elem, depth+1)
 	}
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -14,137 +14,250 @@ import (
 const anErrorStr = "assert.AnError general error for testing"
 
 func TestDereferencePointers(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
 	ptr := func(v string) *string { return &v }
 
-	err := With("hello", "world").Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"hello": "world"}, err.Context())
+	tests := []struct {
+		name        string
+		makeVal     func() any
+		wantCtx     map[string]any
+		equalValues bool
+	}{
+		{
+			name:    "string_value",
+			makeVal: func() any { return "world" },
+			wantCtx: map[string]any{"hello": "world"},
+		},
+		{
+			name:    "string_pointer",
+			makeVal: func() any { return ptr("world") },
+			wantCtx: map[string]any{"hello": "world"},
+		},
+		{
+			name:    "nil_value",
+			makeVal: func() any { return nil },
+			wantCtx: map[string]any{"hello": nil},
+		},
+		{
+			name:    "nil_int_pointer",
+			makeVal: func() any { return (*int)(nil) },
+			wantCtx: map[string]any{"hello": nil},
+		},
+		{
+			name:    "nil_triple_pointer",
+			makeVal: func() any { return (***int)(nil) },
+			wantCtx: map[string]any{"hello": nil},
+		},
+		{
+			name: "nil_through_triple_pointer",
+			makeVal: func() any {
+				var i **int
+				return (***int)(&i) //nolint:unconvert
+			},
+			wantCtx:     map[string]any{"hello": nil},
+			equalValues: true,
+		},
+	}
 
-	err = With("hello", ptr("world")).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"hello": "world"}, err.Context())
-
-	err = With("hello", nil).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"hello": nil}, err.Context())
-
-	err = With("hello", (*int)(nil)).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"hello": nil}, err.Context())
-
-	err = With("hello", (***int)(nil)).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"hello": nil}, err.Context())
-
-	var i **int
-	err = With("hello", (***int)(&i)).Errorf(anErrorStr).(OopsError) //nolint:unconvert
-	is.EqualValues(map[string]any{"hello": nil}, err.Context())      //nolint:testifylint
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			err := With("hello", tt.makeVal()).Errorf(anErrorStr).(OopsError)
+			if tt.equalValues {
+				is.EqualValues(tt.wantCtx, err.Context()) //nolint:testifylint
+			} else {
+				is.Equal(tt.wantCtx, err.Context())
+			}
+		})
+	}
 }
 
 func TestDereferencePointerEdgeCases(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test deeply nested pointers (should not panic)
-	deepValue := "deep"
-	ptr1 := &deepValue
-	ptr2 := &ptr1
-	ptr3 := &ptr2
-	ptr4 := &ptr3
-	ptr5 := &ptr4
-
-	err := With("deep", ptr5).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"deep": "deep"}, err.Context())
-
-	// Test nil pointers at different levels
-	var nilPtr *string
-	err = With("nil1", nilPtr).Errorf(anErrorStr).(OopsError)
-	is.EqualValues(map[string]any{"nil1": nil}, err.Context()) //nolint:testifylint
-
-	var nilPtr2 **string
-	err = With("nil2", nilPtr2).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"nil2": nil}, err.Context())
-
-	// Test mixed nil and non-nil pointers
-	value := "test"
-	valuePtr := &value
-	mixedPtr := &valuePtr
-	err = With("mixed", mixedPtr).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"mixed": "test"}, err.Context())
-
-	// Test with different types
-	intValue := 42
-	intPtr := &intValue
-	err = With("int", intPtr).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"int": 42}, err.Context())
-
-	// Test with struct pointers
-	type testStruct struct {
-		Field string
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "deeply_nested_pointers",
+			run: func(is *assert.Assertions) {
+				deepValue := "deep"
+				ptr1 := &deepValue
+				ptr2 := &ptr1
+				ptr3 := &ptr2
+				ptr4 := &ptr3
+				ptr5 := &ptr4
+				err := With("deep", ptr5).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"deep": "deep"}, err.Context())
+			},
+		},
+		{
+			name: "nil_single_pointer",
+			run: func(is *assert.Assertions) {
+				var nilPtr *string
+				err := With("nil1", nilPtr).Errorf(anErrorStr).(OopsError)
+				is.EqualValues(map[string]any{"nil1": nil}, err.Context()) //nolint:testifylint
+			},
+		},
+		{
+			name: "nil_double_pointer",
+			run: func(is *assert.Assertions) {
+				var nilPtr2 **string
+				err := With("nil2", nilPtr2).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"nil2": nil}, err.Context())
+			},
+		},
+		{
+			name: "mixed_nil_and_non_nil",
+			run: func(is *assert.Assertions) {
+				value := "test"
+				valuePtr := &value
+				mixedPtr := &valuePtr
+				err := With("mixed", mixedPtr).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"mixed": "test"}, err.Context())
+			},
+		},
+		{
+			name: "int_pointer",
+			run: func(is *assert.Assertions) {
+				intValue := 42
+				intPtr := &intValue
+				err := With("int", intPtr).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"int": 42}, err.Context())
+			},
+		},
+		{
+			name: "struct_pointer",
+			run: func(is *assert.Assertions) {
+				type testStruct struct{ Field string }
+				structValue := testStruct{Field: "test"}
+				structPtr := &structValue
+				err := With("struct", structPtr).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"struct": testStruct{Field: "test"}}, err.Context())
+			},
+		},
 	}
-	structValue := testStruct{Field: "test"}
-	structPtr := &structValue
-	err = With("struct", structPtr).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"struct": testStruct{Field: "test"}}, err.Context())
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestDereferencePointerSafety(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with invalid reflect values (should not panic)
-	var invalidPtr unsafe.Pointer
-	err := With("invalid", invalidPtr).Errorf(anErrorStr).(OopsError)
-	// Should handle gracefully without panic
-	is.NotNil(err)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "invalid_pointer",
+			run: func(is *assert.Assertions) {
+				var invalidPtr unsafe.Pointer
+				err := With("invalid", invalidPtr).Errorf(anErrorStr).(OopsError)
+				is.NotNil(err)
+			},
+		},
+		{
+			name: "function_pointer",
+			run: func(is *assert.Assertions) {
+				testFunc := func() string { return "test" }
+				err := With("func", &testFunc).Errorf(anErrorStr).(OopsError)
+				is.NotNil(err)
+			},
+		},
+		{
+			name: "channel_pointer",
+			run: func(is *assert.Assertions) {
+				ch := make(chan int)
+				err := With("channel", &ch).Errorf(anErrorStr).(OopsError)
+				is.NotNil(err)
+			},
+		},
+		{
+			name: "slice_pointer",
+			run: func(is *assert.Assertions) {
+				slice := []int{1, 2, 3}
+				err := With("slice", &slice).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"slice": []int{1, 2, 3}}, err.Context())
+			},
+		},
+		{
+			name: "map_pointer",
+			run: func(is *assert.Assertions) {
+				m := map[string]int{"a": 1, "b": 2}
+				err := With("map", &m).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"map": map[string]int{"a": 1, "b": 2}}, err.Context())
+			},
+		},
+	}
 
-	// Test with function pointers
-	testFunc := func() string { return "test" }
-	err = With("func", &testFunc).Errorf(anErrorStr).(OopsError)
-	// Should handle function pointers gracefully
-	is.NotNil(err)
-
-	// Test with channel pointers
-	ch := make(chan int)
-	err = With("channel", &ch).Errorf(anErrorStr).(OopsError)
-	// Should handle channel pointers gracefully
-	is.NotNil(err)
-
-	// Test with slice pointers
-	slice := []int{1, 2, 3}
-	err = With("slice", &slice).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"slice": []int{1, 2, 3}}, err.Context())
-
-	// Test with map pointers
-	m := map[string]int{"a": 1, "b": 2}
-	err = With("map", &m).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"map": map[string]int{"a": 1, "b": 2}}, err.Context())
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestDereferencePointerComplexTypes(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with interface pointers
-	var iface any = "interface_value"
-	ifacePtr := &iface
-	err := With("interface", ifacePtr).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"interface": "interface_value"}, err.Context())
-
-	// Test with array pointers
-	arr := [3]int{1, 2, 3}
-	arrPtr := &arr
-	err = With("array", arrPtr).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"array": [3]int{1, 2, 3}}, err.Context())
-
-	// Test with nested struct pointers
-	type nestedStruct struct {
-		Inner struct {
-			Value string
-		}
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "interface_pointer",
+			run: func(is *assert.Assertions) {
+				var iface any = "interface_value"
+				ifacePtr := &iface
+				err := With("interface", ifacePtr).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"interface": "interface_value"}, err.Context())
+			},
+		},
+		{
+			name: "array_pointer",
+			run: func(is *assert.Assertions) {
+				arr := [3]int{1, 2, 3}
+				arrPtr := &arr
+				err := With("array", arrPtr).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"array": [3]int{1, 2, 3}}, err.Context())
+			},
+		},
+		{
+			name: "nested_struct_pointer",
+			run: func(is *assert.Assertions) {
+				type nestedStruct struct {
+					Inner struct{ Value string }
+				}
+				nested := nestedStruct{Inner: struct{ Value string }{Value: "nested"}}
+				nestedPtr := &nested
+				err := With("nested", nestedPtr).Errorf(anErrorStr).(OopsError)
+				is.Equal(map[string]any{"nested": nested}, err.Context())
+			},
+		},
 	}
-	nested := nestedStruct{Inner: struct{ Value string }{Value: "nested"}}
-	nestedPtr := &nested
-	err = With("nested", nestedPtr).Errorf(anErrorStr).(OopsError)
-	is.Equal(map[string]any{"nested": nested}, err.Context())
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestDereferencePointerWithDisabled(t *testing.T) { //nolint:paralleltest
@@ -193,70 +306,112 @@ func TestDereferencePointerMultipleValues(t *testing.T) {
 }
 
 func TestDereferencePointerPanicPrevention(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test that the function doesn't panic with extremely deep nesting
-	// This would have caused a stack overflow in the original implementation
-	deepValue := "deep"
-	ptr1 := &deepValue
-	ptr2 := &ptr1
-	ptr3 := &ptr2
-	ptr4 := &ptr3
-	ptr5 := &ptr4
-	ptr6 := &ptr5
-	ptr7 := &ptr6
-	ptr8 := &ptr7
-	ptr9 := &ptr8
-	ptr10 := &ptr9
-	ptr11 := &ptr10 // This exceeds the 10-level limit
-
-	// This should not panic and should return the original value
-	err := With("very_deep", ptr11).Errorf(anErrorStr).(OopsError)
-	is.NotNil(err)
-
-	// The context should contain the pointer as-is since it exceeds the depth limit
-	context := err.Context()
-	is.Contains(context, "very_deep")
-
-	// Test with invalid reflect values that could cause panics
-	var invalidValue any = func() {} // Function type
-	err = With("invalid", &invalidValue).Errorf(anErrorStr).(OopsError)
-	is.NotNil(err)
-
-	// Test with unexported fields that might cause panics when accessing
-	type unexportedStruct struct {
-		unexported string
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			// This would have caused a stack overflow in the original implementation.
+			name: "deeply_nested_exceeds_limit",
+			run: func(is *assert.Assertions) {
+				deepValue := "deep"
+				ptr1 := &deepValue
+				ptr2 := &ptr1
+				ptr3 := &ptr2
+				ptr4 := &ptr3
+				ptr5 := &ptr4
+				ptr6 := &ptr5
+				ptr7 := &ptr6
+				ptr8 := &ptr7
+				ptr9 := &ptr8
+				ptr10 := &ptr9
+				ptr11 := &ptr10 // exceeds the 10-level limit
+				err := With("very_deep", ptr11).Errorf(anErrorStr).(OopsError)
+				is.NotNil(err)
+				is.Contains(err.Context(), "very_deep")
+			},
+		},
+		{
+			name: "function_type",
+			run: func(is *assert.Assertions) {
+				var invalidValue any = func() {}
+				err := With("invalid", &invalidValue).Errorf(anErrorStr).(OopsError)
+				is.NotNil(err)
+			},
+		},
+		{
+			name: "unexported_struct_fields",
+			run: func(is *assert.Assertions) {
+				type unexportedStruct struct{ unexported string }
+				unexported := unexportedStruct{unexported: "test"}
+				err := With("unexported", &unexported).Errorf(anErrorStr).(OopsError)
+				is.NotNil(err)
+			},
+		},
+		{
+			name: "nil_interface",
+			run: func(is *assert.Assertions) {
+				var nilInterface any
+				err := With("nil_interface", &nilInterface).Errorf(anErrorStr).(OopsError)
+				is.NotNil(err)
+			},
+		},
 	}
-	unexported := unexportedStruct{unexported: "test"}
-	err = With("unexported", &unexported).Errorf(anErrorStr).(OopsError)
-	is.NotNil(err)
 
-	// Test with nil interface
-	var nilInterface any
-	err = With("nil_interface", &nilInterface).Errorf(anErrorStr).(OopsError)
-	is.NotNil(err)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestDereferencePointerRecursiveEdgeCases(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with nil pointer
-	var nilPtr *string
-	result := dereferencePointerRecursive(reflect.ValueOf(nilPtr), 0)
-	is.Nil(result)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "nil_pointer",
+			run: func(is *assert.Assertions) {
+				var nilPtr *string
+				result := dereferencePointerRecursive(reflect.ValueOf(nilPtr), 0)
+				is.Nil(result)
+			},
+		},
+		{
+			name: "max_depth_exceeded",
+			run: func(is *assert.Assertions) {
+				value := "test"
+				ptr := &value
+				result := dereferencePointerRecursive(reflect.ValueOf(ptr), 100)
+				is.Equal(ptr, result)
+			},
+		},
+		{
+			name: "invalid_reflect_value",
+			run: func(is *assert.Assertions) {
+				var invalid reflect.Value
+				result := dereferencePointerRecursive(invalid, 0)
+				is.Nil(result)
+			},
+		},
+	}
 
-	// Test with max depth exceeded
-	value := "test"
-	ptr := &value
-	result2 := dereferencePointerRecursive(reflect.ValueOf(ptr), 100)
-	is.Equal(ptr, result2) // Should return the pointer itself
-
-	// Test with invalid reflect value
-	var invalid reflect.Value
-	result3 := dereferencePointerRecursive(invalid, 0)
-	is.Nil(result3)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestLazyMapEvaluation(t *testing.T) {
@@ -307,8 +462,10 @@ func TestLazyMapEvaluation(t *testing.T) {
 			is := assert.New(t)
 
 			got := lazyMapEvaluation(tt.input)
+			is.Len(got, len(tt.want))
 			// Compare func entries by kind only (functions aren't directly comparable).
 			for k, wantVal := range tt.want {
+				is.Contains(got, k, "key %q missing from result", k)
 				if wantVal != nil && reflect.TypeOf(wantVal).Kind() == reflect.Func {
 					is.Equal(reflect.Func, reflect.TypeOf(got[k]).Kind(), "key %q", k)
 				} else {
@@ -320,24 +477,44 @@ func TestLazyMapEvaluation(t *testing.T) {
 }
 
 func TestLazyValueEvaluationEdgeCases(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with nil value
-	result := lazyValueEvaluation(nil)
-	is.Nil(result)
-
-	// Test with non-function value
-	result2 := lazyValueEvaluation("string")
-	is.Equal("string", result2)
-
-	// Test with function that returns error
-	fn := func() (string, error) {
-		return "test", assert.AnError
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "nil_value",
+			run: func(is *assert.Assertions) {
+				result := lazyValueEvaluation(nil)
+				is.Nil(result)
+			},
+		},
+		{
+			name: "non_function_value",
+			run: func(is *assert.Assertions) {
+				result := lazyValueEvaluation("string")
+				is.Equal("string", result)
+			},
+		},
+		{
+			name: "function_returning_error",
+			run: func(is *assert.Assertions) {
+				fn := func() (string, error) { return "test", assert.AnError }
+				result := lazyValueEvaluation(fn)
+				is.Equal(reflect.Func, reflect.TypeOf(result).Kind())
+			},
+		},
 	}
-	result3 := lazyValueEvaluation(fn)
-	// Should return function as-is when it returns error
-	is.Equal(reflect.Func, reflect.TypeOf(result3).Kind())
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestRecursive(t *testing.T) {

--- a/oops_n_test.go
+++ b/oops_n_test.go
@@ -8,200 +8,282 @@ import (
 )
 
 func TestWrapFunctions(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test Wrap2
-	result, err := Wrap2("test", assert.AnError)
-	is.Error(err)
-	is.Equal("test", result)
-	is.Equal(assert.AnError, err.(OopsError).err)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "Wrap2",
+			run: func(is *assert.Assertions) {
+				result, err := Wrap2("test", assert.AnError)
+				is.Error(err)
+				is.Equal("test", result)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap3",
+			run: func(is *assert.Assertions) {
+				result1, result2, err := Wrap3("test", "domain", assert.AnError)
+				is.Error(err)
+				is.Equal("test", result1)
+				is.Equal("domain", result2)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap4",
+			run: func(is *assert.Assertions) {
+				r1, r2, r3, err := Wrap4("test", "domain", "code", assert.AnError)
+				is.Error(err)
+				is.Equal("test", r1)
+				is.Equal("domain", r2)
+				is.Equal("code", r3)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap5",
+			run: func(is *assert.Assertions) {
+				val1, val2, val3, val4, err := Wrap5("test", "domain", "code", "hint", assert.AnError)
+				is.Error(err)
+				is.Equal("test", val1)
+				is.Equal("domain", val2)
+				is.Equal("code", val3)
+				is.Equal("hint", val4)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap6",
+			run: func(is *assert.Assertions) {
+				v1, v2, v3, v4, v5, err := Wrap6("test", "domain", "code", "hint", "user", assert.AnError)
+				is.Error(err)
+				is.Equal("test", v1)
+				is.Equal("domain", v2)
+				is.Equal("code", v3)
+				is.Equal("hint", v4)
+				is.Equal("user", v5)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap7",
+			run: func(is *assert.Assertions) {
+				w1, w2, w3, w4, w5, w6, err := Wrap7("test", "domain", "code", "hint", "user", "tenant", assert.AnError)
+				is.Error(err)
+				is.Equal("test", w1)
+				is.Equal("domain", w2)
+				is.Equal("code", w3)
+				is.Equal("hint", w4)
+				is.Equal("user", w5)
+				is.Equal("tenant", w6)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap8",
+			run: func(is *assert.Assertions) {
+				x1, x2, x3, x4, x5, x6, x7, err := Wrap8("test", "domain", "code", "hint", "user", "tenant", "request", assert.AnError)
+				is.Error(err)
+				is.Equal("test", x1)
+				is.Equal("domain", x2)
+				is.Equal("code", x3)
+				is.Equal("hint", x4)
+				is.Equal("user", x5)
+				is.Equal("tenant", x6)
+				is.Equal("request", x7)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap9",
+			run: func(is *assert.Assertions) {
+				y1, y2, y3, y4, y5, y6, y7, y8, err := Wrap9("test", "domain", "code", "hint", "user", "tenant", "request", "response", assert.AnError)
+				is.Error(err)
+				is.Equal("test", y1)
+				is.Equal("domain", y2)
+				is.Equal("code", y3)
+				is.Equal("hint", y4)
+				is.Equal("user", y5)
+				is.Equal("tenant", y6)
+				is.Equal("request", y7)
+				is.Equal("response", y8)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+		{
+			name: "Wrap10",
+			run: func(is *assert.Assertions) {
+				z1, z2, z3, z4, z5, z6, z7, z8, z9, err := Wrap10("test", "domain", "code", "hint", "user", "tenant", "request", "response", "stack", assert.AnError)
+				is.Error(err)
+				is.Equal("test", z1)
+				is.Equal("domain", z2)
+				is.Equal("code", z3)
+				is.Equal("hint", z4)
+				is.Equal("user", z5)
+				is.Equal("tenant", z6)
+				is.Equal("request", z7)
+				is.Equal("response", z8)
+				is.Equal("stack", z9)
+				is.Equal(assert.AnError, err.(OopsError).err)
+			},
+		},
+	}
 
-	// Test Wrap3
-	result1, result2, err2 := Wrap3("test", "domain", assert.AnError)
-	is.Error(err2)
-	is.Equal("test", result1)
-	is.Equal("domain", result2)
-	is.Equal(assert.AnError, err2.(OopsError).err)
-
-	// Test Wrap4
-	r1, r2, r3, err3 := Wrap4("test", "domain", "code", assert.AnError)
-	is.Error(err3)
-	is.Equal("test", r1)
-	is.Equal("domain", r2)
-	is.Equal("code", r3)
-	is.Equal(assert.AnError, err3.(OopsError).err)
-
-	// Test Wrap5
-	val1, val2, val3, val4, err4 := Wrap5("test", "domain", "code", "hint", assert.AnError)
-	is.Error(err4)
-	is.Equal("test", val1)
-	is.Equal("domain", val2)
-	is.Equal("code", val3)
-	is.Equal("hint", val4)
-	is.Equal(assert.AnError, err4.(OopsError).err)
-
-	// Test Wrap6
-	v1, v2, v3, v4, v5, err5 := Wrap6("test", "domain", "code", "hint", "user", assert.AnError)
-	is.Error(err5)
-	is.Equal("test", v1)
-	is.Equal("domain", v2)
-	is.Equal("code", v3)
-	is.Equal("hint", v4)
-	is.Equal("user", v5)
-	is.Equal(assert.AnError, err5.(OopsError).err)
-
-	// Test Wrap7
-	w1, w2, w3, w4, w5, w6, err6 := Wrap7("test", "domain", "code", "hint", "user", "tenant", assert.AnError)
-	is.Error(err6)
-	is.Equal("test", w1)
-	is.Equal("domain", w2)
-	is.Equal("code", w3)
-	is.Equal("hint", w4)
-	is.Equal("user", w5)
-	is.Equal("tenant", w6)
-	is.Equal(assert.AnError, err6.(OopsError).err)
-
-	// Test Wrap8
-	x1, x2, x3, x4, x5, x6, x7, err7 := Wrap8("test", "domain", "code", "hint", "user", "tenant", "request", assert.AnError)
-	is.Error(err7)
-	is.Equal("test", x1)
-	is.Equal("domain", x2)
-	is.Equal("code", x3)
-	is.Equal("hint", x4)
-	is.Equal("user", x5)
-	is.Equal("tenant", x6)
-	is.Equal("request", x7)
-	is.Equal(assert.AnError, err7.(OopsError).err)
-
-	// Test Wrap9
-	y1, y2, y3, y4, y5, y6, y7, y8, err8 := Wrap9("test", "domain", "code", "hint", "user", "tenant", "request", "response", assert.AnError)
-	is.Error(err8)
-	is.Equal("test", y1)
-	is.Equal("domain", y2)
-	is.Equal("code", y3)
-	is.Equal("hint", y4)
-	is.Equal("user", y5)
-	is.Equal("tenant", y6)
-	is.Equal("request", y7)
-	is.Equal("response", y8)
-	is.Equal(assert.AnError, err8.(OopsError).err)
-
-	// Test Wrap10
-	z1, z2, z3, z4, z5, z6, z7, z8, z9, err9 := Wrap10("test", "domain", "code", "hint", "user", "tenant", "request", "response", "stack", assert.AnError)
-	is.Error(err9)
-	is.Equal("test", z1)
-	is.Equal("domain", z2)
-	is.Equal("code", z3)
-	is.Equal("hint", z4)
-	is.Equal("user", z5)
-	is.Equal("tenant", z6)
-	is.Equal("request", z7)
-	is.Equal("response", z8)
-	is.Equal("stack", z9)
-	is.Equal(assert.AnError, err9.(OopsError).err)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestWrapfFunctions(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test Wrapf2
-	result, err := Wrapf2("test", assert.AnError, "test %d", 42)
-	is.Error(err)
-	is.Equal("test", result)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("test 42", err.(OopsError).msg)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "Wrapf2",
+			run: func(is *assert.Assertions) {
+				result, err := Wrapf2("test", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", result)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf3",
+			run: func(is *assert.Assertions) {
+				result1, result2, err := Wrapf3("test", "domain", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", result1)
+				is.Equal("domain", result2)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf4",
+			run: func(is *assert.Assertions) {
+				r1, r2, r3, err := Wrapf4("test", "domain", "code", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", r1)
+				is.Equal("domain", r2)
+				is.Equal("code", r3)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf5",
+			run: func(is *assert.Assertions) {
+				val1, val2, val3, val4, err := Wrapf5("test", "domain", "code", "hint", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", val1)
+				is.Equal("domain", val2)
+				is.Equal("code", val3)
+				is.Equal("hint", val4)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf6",
+			run: func(is *assert.Assertions) {
+				v1, v2, v3, v4, v5, err := Wrapf6("test", "domain", "code", "hint", "user", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", v1)
+				is.Equal("domain", v2)
+				is.Equal("code", v3)
+				is.Equal("hint", v4)
+				is.Equal("user", v5)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf7",
+			run: func(is *assert.Assertions) {
+				w1, w2, w3, w4, w5, w6, err := Wrapf7("test", "domain", "code", "hint", "user", "tenant", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", w1)
+				is.Equal("domain", w2)
+				is.Equal("code", w3)
+				is.Equal("hint", w4)
+				is.Equal("user", w5)
+				is.Equal("tenant", w6)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf8",
+			run: func(is *assert.Assertions) {
+				x1, x2, x3, x4, x5, x6, x7, err := Wrapf8("test", "domain", "code", "hint", "user", "tenant", "request", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", x1)
+				is.Equal("domain", x2)
+				is.Equal("code", x3)
+				is.Equal("hint", x4)
+				is.Equal("user", x5)
+				is.Equal("tenant", x6)
+				is.Equal("request", x7)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf9",
+			run: func(is *assert.Assertions) {
+				y1, y2, y3, y4, y5, y6, y7, y8, err := Wrapf9("test", "domain", "code", "hint", "user", "tenant", "request", "response", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", y1)
+				is.Equal("domain", y2)
+				is.Equal("code", y3)
+				is.Equal("hint", y4)
+				is.Equal("user", y5)
+				is.Equal("tenant", y6)
+				is.Equal("request", y7)
+				is.Equal("response", y8)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+		{
+			name: "Wrapf10",
+			run: func(is *assert.Assertions) {
+				z1, z2, z3, z4, z5, z6, z7, z8, z9, err := Wrapf10("test", "domain", "code", "hint", "user", "tenant", "request", "response", "stack", assert.AnError, "test %d", 42)
+				is.Error(err)
+				is.Equal("test", z1)
+				is.Equal("domain", z2)
+				is.Equal("code", z3)
+				is.Equal("hint", z4)
+				is.Equal("user", z5)
+				is.Equal("tenant", z6)
+				is.Equal("request", z7)
+				is.Equal("response", z8)
+				is.Equal("stack", z9)
+				is.Equal(assert.AnError, err.(OopsError).err)
+				is.Equal("test 42", err.(OopsError).msg)
+			},
+		},
+	}
 
-	// Test Wrapf3
-	result1, result2, err2 := Wrapf3("test", "domain", assert.AnError, "test %d", 42)
-	is.Error(err2)
-	is.Equal("test", result1)
-	is.Equal("domain", result2)
-	is.Equal(assert.AnError, err2.(OopsError).err)
-	is.Equal("test 42", err2.(OopsError).msg)
-
-	// Test Wrapf4
-	r1, r2, r3, err3 := Wrapf4("test", "domain", "code", assert.AnError, "test %d", 42)
-	is.Error(err3)
-	is.Equal("test", r1)
-	is.Equal("domain", r2)
-	is.Equal("code", r3)
-	is.Equal(assert.AnError, err3.(OopsError).err)
-	is.Equal("test 42", err3.(OopsError).msg)
-
-	// Test Wrapf5
-	val1, val2, val3, val4, err4 := Wrapf5("test", "domain", "code", "hint", assert.AnError, "test %d", 42)
-	is.Error(err4)
-	is.Equal("test", val1)
-	is.Equal("domain", val2)
-	is.Equal("code", val3)
-	is.Equal("hint", val4)
-	is.Equal(assert.AnError, err4.(OopsError).err)
-	is.Equal("test 42", err4.(OopsError).msg)
-
-	// Test Wrapf6
-	v1, v2, v3, v4, v5, err5 := Wrapf6("test", "domain", "code", "hint", "user", assert.AnError, "test %d", 42)
-	is.Error(err5)
-	is.Equal("test", v1)
-	is.Equal("domain", v2)
-	is.Equal("code", v3)
-	is.Equal("hint", v4)
-	is.Equal("user", v5)
-	is.Equal(assert.AnError, err5.(OopsError).err)
-	is.Equal("test 42", err5.(OopsError).msg)
-
-	// Test Wrapf7
-	w1, w2, w3, w4, w5, w6, err6 := Wrapf7("test", "domain", "code", "hint", "user", "tenant", assert.AnError, "test %d", 42)
-	is.Error(err6)
-	is.Equal("test", w1)
-	is.Equal("domain", w2)
-	is.Equal("code", w3)
-	is.Equal("hint", w4)
-	is.Equal("user", w5)
-	is.Equal("tenant", w6)
-	is.Equal(assert.AnError, err6.(OopsError).err)
-	is.Equal("test 42", err6.(OopsError).msg)
-
-	// Test Wrapf8
-	x1, x2, x3, x4, x5, x6, x7, err7 := Wrapf8("test", "domain", "code", "hint", "user", "tenant", "request", assert.AnError, "test %d", 42)
-	is.Error(err7)
-	is.Equal("test", x1)
-	is.Equal("domain", x2)
-	is.Equal("code", x3)
-	is.Equal("hint", x4)
-	is.Equal("user", x5)
-	is.Equal("tenant", x6)
-	is.Equal("request", x7)
-	is.Equal(assert.AnError, err7.(OopsError).err)
-	is.Equal("test 42", err7.(OopsError).msg)
-
-	// Test Wrapf9
-	y1, y2, y3, y4, y5, y6, y7, y8, err8 := Wrapf9("test", "domain", "code", "hint", "user", "tenant", "request", "response", assert.AnError, "test %d", 42)
-	is.Error(err8)
-	is.Equal("test", y1)
-	is.Equal("domain", y2)
-	is.Equal("code", y3)
-	is.Equal("hint", y4)
-	is.Equal("user", y5)
-	is.Equal("tenant", y6)
-	is.Equal("request", y7)
-	is.Equal("response", y8)
-	is.Equal(assert.AnError, err8.(OopsError).err)
-	is.Equal("test 42", err8.(OopsError).msg)
-
-	// Test Wrapf10
-	z1, z2, z3, z4, z5, z6, z7, z8, z9, err9 := Wrapf10("test", "domain", "code", "hint", "user", "tenant", "request", "response", "stack", assert.AnError, "test %d", 42)
-	is.Error(err9)
-	is.Equal("test", z1)
-	is.Equal("domain", z2)
-	is.Equal("code", z3)
-	is.Equal("hint", z4)
-	is.Equal("user", z5)
-	is.Equal("tenant", z6)
-	is.Equal("request", z7)
-	is.Equal("response", z8)
-	is.Equal("stack", z9)
-	is.Equal(assert.AnError, err9.(OopsError).err)
-	is.Equal("test 42", err9.(OopsError).msg)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }

--- a/oops_test.go
+++ b/oops_test.go
@@ -225,56 +225,94 @@ func TestOopsTxSpanFromOtel(t *testing.T) {
 }
 
 func TestOopsWith(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	err := newBuilder().With("user_id", 1234).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{"user_id": 1234}, err.(OopsError).context)
-	err = newBuilder().With("user_id", 1234, "foo").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{"user_id": 1234}, err.(OopsError).context)
-	err = newBuilder().With("user_id", 1234, "foo", "bar").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{"user_id": 1234, "foo": "bar"}, err.(OopsError).context)
+	tests := []struct {
+		name    string
+		args    []any
+		wantCtx map[string]any
+	}{
+		{
+			name:    "single_pair",
+			args:    []any{"user_id", 1234},
+			wantCtx: map[string]any{"user_id": 1234},
+		},
+		{
+			name:    "odd_args_ignored",
+			args:    []any{"user_id", 1234, "foo"},
+			wantCtx: map[string]any{"user_id": 1234},
+		},
+		{
+			name:    "two_pairs",
+			args:    []any{"user_id", 1234, "foo", "bar"},
+			wantCtx: map[string]any{"user_id": 1234, "foo": "bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			err := newBuilder().With(tt.args...).Wrap(assert.AnError)
+			is.Error(err)
+			is.Equal(assert.AnError, err.(OopsError).err)
+			is.Equal(tt.wantCtx, err.(OopsError).context)
+		})
+	}
 }
 
 func TestOopsWithContext(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
 	type test string
 	const fooo test = "fooo"
 	ctx := context.WithValue(context.Background(), "foo", "bar") //nolint:staticcheck,revive
 	ctx = context.WithValue(ctx, fooo, "baz")
-	// string
-	err := newBuilder().WithContext(ctx, "foo").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{"foo": "bar"}, err.(OopsError).context)
-	// type alias
-	err = newBuilder().WithContext(ctx, fooo).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{"fooo": "baz"}, err.(OopsError).context)
-	// multiple
-	err = newBuilder().WithContext(ctx, "foo", fooo).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{"foo": "bar", "fooo": "baz"}, err.(OopsError).context)
-	// not found
-	err = newBuilder().WithContext(ctx, "bar").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{"bar": nil}, err.(OopsError).context)
-	// none
-	err = newBuilder().WithContext(ctx).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal(map[string]any{}, err.(OopsError).context)
+
+	tests := []struct {
+		name    string
+		keys    []any
+		wantCtx map[string]any
+	}{
+		{
+			name:    "string_key",
+			keys:    []any{"foo"},
+			wantCtx: map[string]any{"foo": "bar"},
+		},
+		{
+			name:    "type_alias_key",
+			keys:    []any{fooo},
+			wantCtx: map[string]any{"fooo": "baz"},
+		},
+		{
+			name:    "multiple_keys",
+			keys:    []any{"foo", fooo},
+			wantCtx: map[string]any{"foo": "bar", "fooo": "baz"},
+		},
+		{
+			name:    "not_found",
+			keys:    []any{"bar"},
+			wantCtx: map[string]any{"bar": nil},
+		},
+		{
+			name:    "no_keys",
+			keys:    []any{},
+			wantCtx: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			err := newBuilder().WithContext(ctx, tt.keys...).Wrap(assert.AnError)
+			is.Error(err)
+			is.Equal(assert.AnError, err.(OopsError).err)
+			is.Equal(tt.wantCtx, err.(OopsError).context)
+		})
+	}
 }
 
 func TestOopsWithLazyEvaluation(t *testing.T) {
@@ -318,119 +356,142 @@ func TestOopsOwner(t *testing.T) {
 }
 
 func TestOopsUser(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	err := newBuilder().User("user-123").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("user-123", err.(OopsError).userID)
-	is.Equal(map[string]any{}, err.(OopsError).userData)
-	err = newBuilder().User("user-123", "firstname", "john").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("user-123", err.(OopsError).userID)
-	is.Equal(map[string]any{"firstname": "john"}, err.(OopsError).userData)
-	err = newBuilder().User("user-123", "firstname", "john", "lastname").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("user-123", err.(OopsError).userID)
-	is.Equal(map[string]any{"firstname": "john", badKey: "lastname"}, err.(OopsError).userData)
-	err = newBuilder().User("user-123", "firstname", "john", "lastname", "doe").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("user-123", err.(OopsError).userID)
-	is.Equal(map[string]any{"firstname": "john", "lastname": "doe"}, err.(OopsError).userData)
-	err = newBuilder().User("user-123", 42).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("user-123", err.(OopsError).userID)
-	is.Equal(map[string]any{badKey: 42}, err.(OopsError).userData)
-	err = newBuilder().User(
-		"user-123",
-		slog.String("firstname", "john"),
-		slog.Group("profile", "lastname", "doe", "age", 42),
-	).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("user-123", err.(OopsError).userID)
-	is.Equal(
-		map[string]any{
-			"firstname": "john",
-			"profile":   map[string]any{"lastname": "doe", "age": int64(42)},
+	tests := []struct {
+		name     string
+		args     []any
+		wantData map[string]any
+	}{
+		{
+			name:     "id_only",
+			args:     nil,
+			wantData: map[string]any{},
 		},
-		err.(OopsError).userData,
-	)
-	err = newBuilder().User(
-		"user-123",
-		map[string]any{"firstname": "john"},
-		"lastname",
-		"doe",
-		map[string]any{"country": "fr"},
-	).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("user-123", err.(OopsError).userID)
-	is.Equal(map[string]any{"firstname": "john", "lastname": "doe", "country": "fr"}, err.(OopsError).userData)
+		{
+			name:     "id_with_one_pair",
+			args:     []any{"firstname", "john"},
+			wantData: map[string]any{"firstname": "john"},
+		},
+		{
+			name:     "id_with_odd_args",
+			args:     []any{"firstname", "john", "lastname"},
+			wantData: map[string]any{"firstname": "john", badKey: "lastname"},
+		},
+		{
+			name:     "id_with_two_pairs",
+			args:     []any{"firstname", "john", "lastname", "doe"},
+			wantData: map[string]any{"firstname": "john", "lastname": "doe"},
+		},
+		{
+			name:     "id_with_non_string_key",
+			args:     []any{42},
+			wantData: map[string]any{badKey: 42},
+		},
+		{
+			name: "id_with_slog_attrs",
+			args: []any{
+				slog.String("firstname", "john"),
+				slog.Group("profile", "lastname", "doe", "age", 42),
+			},
+			wantData: map[string]any{
+				"firstname": "john",
+				"profile":   map[string]any{"lastname": "doe", "age": int64(42)},
+			},
+		},
+		{
+			name: "id_with_mixed_maps_and_pairs",
+			args: []any{
+				map[string]any{"firstname": "john"},
+				"lastname",
+				"doe",
+				map[string]any{"country": "fr"},
+			},
+			wantData: map[string]any{"firstname": "john", "lastname": "doe", "country": "fr"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			err := newBuilder().User("user-123", tt.args...).Wrap(assert.AnError)
+			is.Error(err)
+			is.Equal(assert.AnError, err.(OopsError).err)
+			is.Equal("user-123", err.(OopsError).userID)
+			is.Equal(tt.wantData, err.(OopsError).userData)
+		})
+	}
 }
 
 func TestOopsTenant(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	err := newBuilder().Tenant("workspace-123").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("workspace-123", err.(OopsError).tenantID)
-	is.Equal(map[string]any{}, err.(OopsError).tenantData)
-	err = newBuilder().Tenant("workspace-123", "name", "My 'hello world' project").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("workspace-123", err.(OopsError).tenantID)
-	is.Equal(map[string]any{"name": "My 'hello world' project"}, err.(OopsError).tenantData)
-	err = newBuilder().Tenant("workspace-123", "name", "My 'hello world' project", "date").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("workspace-123", err.(OopsError).tenantID)
-	is.Equal(map[string]any{"name": "My 'hello world' project", badKey: "date"}, err.(OopsError).tenantData)
-	err = newBuilder().Tenant("workspace-123", "name", "My 'hello world' project", "date", "2023-01-01").Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("workspace-123", err.(OopsError).tenantID)
-	is.Equal(map[string]any{"name": "My 'hello world' project", "date": "2023-01-01"}, err.(OopsError).tenantData)
-	err = newBuilder().Tenant(
-		"workspace-123",
-		slog.String("country", "fr"),
-		slog.Group("billing", "plan", "pro", "seats", 42),
-	).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("workspace-123", err.(OopsError).tenantID)
-	is.Equal(
-		map[string]any{
-			"country": "fr",
-			"billing": map[string]any{"plan": "pro", "seats": int64(42)},
+	tests := []struct {
+		name     string
+		args     []any
+		wantData map[string]any
+	}{
+		{
+			name:     "id_only",
+			args:     nil,
+			wantData: map[string]any{},
 		},
-		err.(OopsError).tenantData,
-	)
-	err = newBuilder().Tenant(
-		"workspace-123",
-		map[string]any{"name": "My 'hello world' project"},
-		"date",
-		"2023-01-01",
-		map[string]any{"country": "fr"},
-	).Wrap(assert.AnError)
-	is.Error(err)
-	is.Equal(assert.AnError, err.(OopsError).err)
-	is.Equal("workspace-123", err.(OopsError).tenantID)
-	is.Equal(
-		map[string]any{
-			"name":    "My 'hello world' project",
-			"date":    "2023-01-01",
-			"country": "fr",
+		{
+			name:     "id_with_one_pair",
+			args:     []any{"name", "My 'hello world' project"},
+			wantData: map[string]any{"name": "My 'hello world' project"},
 		},
-		err.(OopsError).tenantData,
-	)
+		{
+			name:     "id_with_odd_args",
+			args:     []any{"name", "My 'hello world' project", "date"},
+			wantData: map[string]any{"name": "My 'hello world' project", badKey: "date"},
+		},
+		{
+			name:     "id_with_two_pairs",
+			args:     []any{"name", "My 'hello world' project", "date", "2023-01-01"},
+			wantData: map[string]any{"name": "My 'hello world' project", "date": "2023-01-01"},
+		},
+		{
+			name: "id_with_slog_attrs",
+			args: []any{
+				slog.String("country", "fr"),
+				slog.Group("billing", "plan", "pro", "seats", 42),
+			},
+			wantData: map[string]any{
+				"country": "fr",
+				"billing": map[string]any{"plan": "pro", "seats": int64(42)},
+			},
+		},
+		{
+			name: "id_with_mixed_maps_and_pairs",
+			args: []any{
+				map[string]any{"name": "My 'hello world' project"},
+				"date",
+				"2023-01-01",
+				map[string]any{"country": "fr"},
+			},
+			wantData: map[string]any{
+				"name":    "My 'hello world' project",
+				"date":    "2023-01-01",
+				"country": "fr",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			err := newBuilder().Tenant("workspace-123", tt.args...).Wrap(assert.AnError)
+			is.Error(err)
+			is.Equal(assert.AnError, err.(OopsError).err)
+			is.Equal("workspace-123", err.(OopsError).tenantID)
+			is.Equal(tt.wantData, err.(OopsError).tenantData)
+		})
+	}
 }
 
 func TestOopsRequest(t *testing.T) {
@@ -839,14 +900,42 @@ func TestOopsMarshalJSON(t *testing.T) {
 }
 
 func TestOopsGetPublic(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	err := newBuilder().Public("public message").Wrap(assert.AnError)
-	is.Equal("public message", GetPublic(err, "default"))
-	err = newBuilder().Wrap(assert.AnError)
-	is.Equal("default", GetPublic(err, "default"))
-	is.Equal("default", GetPublic(nil, "default"))
+	tests := []struct {
+		name     string
+		err      error
+		fallback string
+		want     string
+	}{
+		{
+			name:     "with_public",
+			err:      newBuilder().Public("public message").Wrap(assert.AnError),
+			fallback: "default",
+			want:     "public message",
+		},
+		{
+			name:     "without_public",
+			err:      newBuilder().Wrap(assert.AnError),
+			fallback: "default",
+			want:     "default",
+		},
+		{
+			name:     "nil_error",
+			err:      nil,
+			fallback: "default",
+			want:     "default",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			is.Equal(tt.want, GetPublic(tt.err, tt.fallback))
+		})
+	}
 }
 
 func TestOopsAssert(t *testing.T) {
@@ -968,30 +1057,46 @@ func TestOopsErrorMethods(t *testing.T) {
 }
 
 func TestOopsRecoverEdgeCases(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test recover with non-error panic
-	err := newBuilder().Recover(func() {
-		panic("string panic")
-	})
-	is.Error(err)
-	is.Contains(err.Error(), "string panic")
-	// Test recover with nil panic
-	err = newBuilder().Recover(func() {
-		panic(nil)
-	})
-	is.Error(err)
-	is.Contains(err.Error(), "panic")
-	// Test recover with struct panic
 	type testStruct struct {
 		Field string
 	}
-	err = newBuilder().Recover(func() {
-		panic(testStruct{Field: "test"})
-	})
-	is.Error(err)
-	is.Contains(err.Error(), "test")
+
+	tests := []struct {
+		name         string
+		panicVal     any
+		wantContains string
+	}{
+		{
+			name:         "string_panic",
+			panicVal:     "string panic",
+			wantContains: "string panic",
+		},
+		{
+			name:         "nil_panic",
+			panicVal:     nil,
+			wantContains: "panic",
+		},
+		{
+			name:         "struct_panic",
+			panicVal:     testStruct{Field: "test"},
+			wantContains: "test",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			err := newBuilder().Recover(func() {
+				panic(tt.panicVal)
+			})
+			is.Error(err)
+			is.Contains(err.Error(), tt.wantContains)
+		})
+	}
 }
 
 func TestOopsWithContextEdgeCases(t *testing.T) {
@@ -1015,18 +1120,38 @@ func TestOopsWithContextEdgeCases(t *testing.T) {
 }
 
 func TestOopsErrorFormatEdgeCases(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test error with nil underlying error
-	err := OopsError{msg: "test message"}
-	is.Equal("test message", err.Error())
-	// Test error with empty message
-	err2 := OopsError{err: assert.AnError}
-	is.Equal("assert.AnError general error for testing", err2.Error())
-	// Test error with both message and underlying error
-	err3 := OopsError{err: assert.AnError, msg: "test message"}
-	is.Equal("test message: assert.AnError general error for testing", err3.Error())
+	tests := []struct {
+		name    string
+		oopsErr OopsError
+		want    string
+	}{
+		{
+			name:    "nil_underlying_error",
+			oopsErr: OopsError{msg: "test message"},
+			want:    "test message",
+		},
+		{
+			name:    "empty_message",
+			oopsErr: OopsError{err: assert.AnError},
+			want:    "assert.AnError general error for testing",
+		},
+		{
+			name:    "both_message_and_error",
+			oopsErr: OopsError{err: assert.AnError, msg: "test message"},
+			want:    "test message: assert.AnError general error for testing",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			is.Equal(tt.want, tt.oopsErr.Error())
+		})
+	}
 }
 
 func TestOopsRequestEdgeCases(t *testing.T) {

--- a/recovery/gin/middleware_test.go
+++ b/recovery/gin/middleware_test.go
@@ -35,57 +35,38 @@ func TestGinOopsRecovery_NoPanic(t *testing.T) {
 	}
 }
 
-func TestGinOopsRecovery_PanicWithString(t *testing.T) {
+func TestGinOopsRecovery_PanicWith(t *testing.T) {
 	t.Parallel()
 
-	router := gin.New()
-	router.Use(GinOopsRecovery())
-	router.GET("/panic-string", func(c *gin.Context) {
-		panic("something went wrong")
-	})
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/panic-string", nil)
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected status 500, got %d", w.Code)
+	tests := []struct {
+		name     string
+		path     string
+		panicVal any
+	}{
+		{name: "string", path: "/panic-string", panicVal: "something went wrong"},
+		{name: "error", path: "/panic-error", panicVal: errors.New("db failure")},
+		{name: "int", path: "/panic-int", panicVal: 42},
 	}
-}
 
-func TestGinOopsRecovery_PanicWithError(t *testing.T) {
-	t.Parallel()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	router := gin.New()
-	router.Use(GinOopsRecovery())
-	router.GET("/panic-error", func(c *gin.Context) {
-		panic(errors.New("db failure"))
-	})
+			router := gin.New()
+			router.Use(GinOopsRecovery())
+			router.GET(tt.path, func(c *gin.Context) {
+				panic(tt.panicVal)
+			})
 
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/panic-error", nil)
-	router.ServeHTTP(w, req)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected status 500, got %d", w.Code)
-	}
-}
-
-func TestGinOopsRecovery_PanicWithInt(t *testing.T) {
-	t.Parallel()
-
-	router := gin.New()
-	router.Use(GinOopsRecovery())
-	router.GET("/panic-int", func(c *gin.Context) {
-		panic(42)
-	})
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/panic-int", nil)
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected status 500, got %d", w.Code)
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("expected status 500, got %d", w.Code)
+			}
+		})
 	}
 }
 

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -91,69 +91,118 @@ func TestShortFuncNameExtended(t *testing.T) {
 }
 
 func TestOopsStacktraceError(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test stacktrace Error method - returns formatted stacktrace, not span
-	st := &oopsStacktrace{span: "test"}
-	err := st.Error()
-	is.Empty(err) // Empty because no frames
+	frame := oopsStacktraceFrame{file: "test.go", line: 10, function: "testFunc"}
 
-	// Test with frames
-	frame := oopsStacktraceFrame{
-		file:     "test.go",
-		line:     10,
-		function: "testFunc",
+	tests := []struct {
+		name         string
+		st           *oopsStacktrace
+		wantEmpty    bool
+		wantContains string
+	}{
+		{
+			name:      "empty_frames",
+			st:        &oopsStacktrace{span: "test"},
+			wantEmpty: true,
+		},
+		{
+			name:         "with_frames",
+			st:           &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{frame}},
+			wantContains: "test.go:10 testFunc()",
+		},
 	}
-	st2 := &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{frame}}
-	err2 := st2.Error()
-	is.Contains(err2, "test.go:10 testFunc()")
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			result := tt.st.Error()
+			if tt.wantEmpty {
+				is.Empty(result)
+			} else {
+				is.Contains(result, tt.wantContains)
+			}
+		})
+	}
 }
 
 func TestOopsStacktraceString(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with empty frames
-	st := &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{}}
-	result := st.String("")
-	is.Empty(result)
+	frame := oopsStacktraceFrame{file: "test.go", line: 10, function: "testFunc"}
 
-	// Test with frames
-	frame := oopsStacktraceFrame{
-		file:     "test.go",
-		line:     10,
-		function: "testFunc",
+	tests := []struct {
+		name         string
+		st           *oopsStacktrace
+		deepest      string
+		wantEmpty    bool
+		wantContains string
+	}{
+		{
+			name:      "empty_frames",
+			st:        &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{}},
+			deepest:   "",
+			wantEmpty: true,
+		},
+		{
+			name:         "with_frames",
+			st:           &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{frame}},
+			deepest:      "",
+			wantContains: "test.go:10 testFunc()",
+		},
+		{
+			name:      "matching_deepest_frame_excluded",
+			st:        &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{frame}},
+			deepest:   "test.go:10 testFunc()",
+			wantEmpty: true,
+		},
 	}
-	st2 := &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{frame}}
-	result2 := st2.String("")
-	is.Contains(result2, "test.go:10 testFunc()")
 
-	// Test with deepest frame
-	result3 := st2.String("test.go:10 testFunc()")
-	is.Empty(result3)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			result := tt.st.String(tt.deepest)
+			if tt.wantEmpty {
+				is.Empty(result)
+			} else {
+				is.Contains(result, tt.wantContains)
+			}
+		})
+	}
 }
 
 func TestOopsStacktraceFrameString(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with function
-	frame := &oopsStacktraceFrame{
-		file:     "test.go",
-		line:     10,
-		function: "testFunc",
+	tests := []struct {
+		name  string
+		frame *oopsStacktraceFrame
+		want  string
+	}{
+		{
+			name:  "with_function",
+			frame: &oopsStacktraceFrame{file: "test.go", line: 10, function: "testFunc"},
+			want:  "test.go:10 testFunc()",
+		},
+		{
+			name:  "without_function",
+			frame: &oopsStacktraceFrame{file: "test.go", line: 10},
+			want:  "test.go:10",
+		},
 	}
-	result := frame.String()
-	is.Equal("test.go:10 testFunc()", result)
 
-	// Test without function
-	frame2 := &oopsStacktraceFrame{
-		file: "test.go",
-		line: 10,
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			is.Equal(tt.want, tt.frame.String())
+		})
 	}
-	result2 := frame2.String()
-	is.Equal("test.go:10", result2)
 }
 
 // helperWrap wraps oops.Wrap without any caller skip — it should appear in the stack trace.

--- a/utils_test.go
+++ b/utils_test.go
@@ -8,36 +8,77 @@ import (
 )
 
 func TestCoalesceOrEmpty(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with non-empty values
-	result := coalesceOrEmpty("", "test", "another")
-	is.Equal("test", result)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "non_empty_values",
+			run: func(is *assert.Assertions) {
+				is.Equal("test", coalesceOrEmpty("", "test", "another"))
+			},
+		},
+		{
+			name: "all_empty",
+			run: func(is *assert.Assertions) {
+				is.Empty(coalesceOrEmpty("", "", ""))
+			},
+		},
+		{
+			name: "no_values",
+			run: func(is *assert.Assertions) {
+				is.Empty(coalesceOrEmpty[string]())
+			},
+		},
+	}
 
-	// Test with all empty values
-	result2 := coalesceOrEmpty("", "", "")
-	is.Empty(result2)
-
-	// Test with no values
-	result3 := coalesceOrEmpty[string]()
-	is.Empty(result3)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }
 
 func TestContextValueOrNil(t *testing.T) {
-	is := assert.New(t)
 	t.Parallel()
 
-	// Test with context containing value
-	ctx := context.WithValue(context.Background(), "key", "value") //nolint:staticcheck
-	result := contextValueOrNil(ctx, "key")
-	is.Equal("value", result)
+	tests := []struct {
+		name string
+		run  func(is *assert.Assertions)
+	}{
+		{
+			name: "value_found",
+			run: func(is *assert.Assertions) {
+				ctx := context.WithValue(context.Background(), "key", "value") //nolint:staticcheck
+				is.Equal("value", contextValueOrNil(ctx, "key"))
+			},
+		},
+		{
+			name: "key_not_found",
+			run: func(is *assert.Assertions) {
+				ctx := context.WithValue(context.Background(), "key", "value") //nolint:staticcheck
+				is.Nil(contextValueOrNil(ctx, "nonexistent"))
+			},
+		},
+		{
+			name: "nil_context",
+			run: func(is *assert.Assertions) {
+				is.Nil(contextValueOrNil(nil, "key")) //nolint:staticcheck
+			},
+		},
+	}
 
-	// Test with context not containing key
-	result2 := contextValueOrNil(ctx, "nonexistent")
-	is.Nil(result2)
-
-	// Test with nil context
-	result3 := contextValueOrNil(nil, "key") //nolint:staticcheck
-	is.Nil(result3)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			is := assert.New(t)
+			tt.run(is)
+		})
+	}
 }


### PR DESCRIPTION
Replace sequential flat assertions with Go idiomatic table-driven tests
across all test files for better readability and coverage visibility.
