### PR TITLE
perf(error): cut intermediate allocations in LogValue, ToMap and formatVerbose

### DIFF
--- a/error.go
+++ b/error.go
@@ -632,32 +632,35 @@ func (o OopsError) LogValue() slog.Value { //nolint:gocyclo
 	}
 
 	if len(s.context) > 0 {
-		attrs = append(attrs,
-			slog.Group(
-				"context",
-				lo.ToAnySlice(
-					lo.MapToSlice(s.context, slog.Any),
-				)...,
-			),
-		)
+		// Build the []any argument list directly instead of going through
+		// lo.MapToSlice + lo.ToAnySlice, which allocates two intermediate slices.
+		args := make([]any, 0, len(s.context))
+		for k, v := range s.context {
+			args = append(args, slog.Any(k, v))
+		}
+		attrs = append(attrs, slog.Group("context", args...))
 	}
 
 	if s.userID != "" || len(s.userData) > 0 {
-		userPayload := []slog.Attr{}
+		userPayload := make([]any, 0, len(s.userData)+1)
 		if s.userID != "" {
 			userPayload = append(userPayload, slog.String("id", s.userID))
-			userPayload = append(userPayload, lo.MapToSlice(s.userData, slog.Any)...)
+			for k, v := range s.userData {
+				userPayload = append(userPayload, slog.Any(k, v))
+			}
 		}
-		attrs = append(attrs, slog.Group("user", lo.ToAnySlice(userPayload)...))
+		attrs = append(attrs, slog.Group("user", userPayload...))
 	}
 
 	if s.tenantID != "" || len(s.tenantData) > 0 {
-		tenantPayload := []slog.Attr{}
+		tenantPayload := make([]any, 0, len(s.tenantData)+1)
 		if s.tenantID != "" {
 			tenantPayload = append(tenantPayload, slog.String("id", s.tenantID))
-			tenantPayload = append(tenantPayload, lo.MapToSlice(s.tenantData, slog.Any)...)
+			for k, v := range s.tenantData {
+				tenantPayload = append(tenantPayload, slog.Any(k, v))
+			}
 		}
-		attrs = append(attrs, slog.Group("tenant", lo.ToAnySlice(tenantPayload)...))
+		attrs = append(attrs, slog.Group("tenant", tenantPayload...))
 	}
 
 	if s.req != nil {
@@ -741,7 +744,9 @@ func (o OopsError) ToMap() map[string]any { //nolint:gocyclo
 	}
 
 	if s.userID != "" || len(s.userData) > 0 {
-		user := lo.Assign(map[string]any{}, s.userData)
+		// snapshot() owns s.userData (freshly merged in mergeMaps), so it can
+		// be used directly instead of copying.
+		user := s.userData
 		if s.userID != "" {
 			user["id"] = s.userID
 		}
@@ -749,7 +754,9 @@ func (o OopsError) ToMap() map[string]any { //nolint:gocyclo
 	}
 
 	if s.tenantID != "" || len(s.tenantData) > 0 {
-		tenant := lo.Assign(map[string]any{}, s.tenantData)
+		// snapshot() owns s.tenantData (freshly merged in mergeMaps), so it can
+		// be used directly instead of copying.
+		tenant := s.tenantData
 		if s.tenantID != "" {
 			tenant["id"] = s.tenantID
 		}
@@ -885,22 +892,16 @@ func (o *OopsError) formatVerbose() string { //nolint:gocyclo
 	if s.req != nil {
 		dump, e := httputil.DumpRequestOut(s.req.A, s.req.B)
 		if e == nil {
-			lines := strings.Split(string(dump), "\n")
-			lines = lo.Map(lines, func(line string, _ int) string {
-				return "  * " + line
-			})
-			_, _ = fmt.Fprintf(&output, "Request:\n%s\n", strings.Join(lines, "\n"))
+			output.WriteString("Request:\n")
+			writePrefixedLines(&output, string(dump))
 		}
 	}
 
 	if s.res != nil {
 		dump, e := httputil.DumpResponse(s.res.A, s.res.B)
 		if e == nil {
-			lines := strings.Split(string(dump), "\n")
-			lines = lo.Map(lines, func(line string, _ int) string {
-				return "  * " + line
-			})
-			_, _ = fmt.Fprintf(&output, "Response:\n%s\n", strings.Join(lines, "\n"))
+			output.WriteString("Response:\n")
+			writePrefixedLines(&output, string(dump))
 		}
 	}
 
@@ -920,4 +921,23 @@ func (o *OopsError) formatVerbose() string { //nolint:gocyclo
 // formatSummary returns a brief summary of the error for logging.
 func (o *OopsError) formatSummary() string {
 	return o.Error()
+}
+
+// writePrefixedLines writes s to output with each line prefixed by "  * ",
+// followed by a trailing newline. Equivalent to splitting on "\n", prefixing
+// every element (including a trailing empty one), and joining - but in a
+// single pass without the intermediate slices.
+func writePrefixedLines(output *strings.Builder, s string) {
+	for {
+		output.WriteString("  * ")
+		idx := strings.IndexByte(s, '\n')
+		if idx < 0 {
+			output.WriteString(s)
+			output.WriteByte('\n')
+			return
+		}
+		output.WriteString(s[:idx])
+		output.WriteByte('\n')
+		s = s[idx+1:]
+	}
 }

--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@
 package oops
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -632,8 +633,6 @@ func (o OopsError) LogValue() slog.Value { //nolint:gocyclo
 	}
 
 	if len(s.context) > 0 {
-		// Build the []any argument list directly instead of going through
-		// lo.MapToSlice + lo.ToAnySlice, which allocates two intermediate slices.
 		args := make([]any, 0, len(s.context))
 		for k, v := range s.context {
 			args = append(args, slog.Any(k, v))
@@ -893,7 +892,7 @@ func (o *OopsError) formatVerbose() string { //nolint:gocyclo
 		dump, e := httputil.DumpRequestOut(s.req.A, s.req.B)
 		if e == nil {
 			output.WriteString("Request:\n")
-			writePrefixedLines(&output, string(dump))
+			writePrefixedLines(&output, dump)
 		}
 	}
 
@@ -901,7 +900,7 @@ func (o *OopsError) formatVerbose() string { //nolint:gocyclo
 		dump, e := httputil.DumpResponse(s.res.A, s.res.B)
 		if e == nil {
 			output.WriteString("Response:\n")
-			writePrefixedLines(&output, string(dump))
+			writePrefixedLines(&output, dump)
 		}
 	}
 
@@ -927,16 +926,20 @@ func (o *OopsError) formatSummary() string {
 // followed by a trailing newline. Equivalent to splitting on "\n", prefixing
 // every element (including a trailing empty one), and joining - but in a
 // single pass without the intermediate slices.
-func writePrefixedLines(output *strings.Builder, s string) {
+//
+// s is taken as []byte rather than string because both callers hold a
+// httputil dump as []byte already; accepting []byte here avoids the
+// string(dump) copy that a string parameter would force at the call site.
+func writePrefixedLines(output *strings.Builder, s []byte) {
 	for {
 		output.WriteString("  * ")
-		idx := strings.IndexByte(s, '\n')
+		idx := bytes.IndexByte(s, '\n')
 		if idx < 0 {
-			output.WriteString(s)
+			output.Write(s)
 			output.WriteByte('\n')
 			return
 		}
-		output.WriteString(s[:idx])
+		output.Write(s[:idx])
 		output.WriteByte('\n')
 		s = s[idx+1:]
 	}


### PR DESCRIPTION
## Summary

- `LogValue`: build the `[]any` `slog.Group` argument lists directly instead of `lo.MapToSlice` followed by `lo.ToAnySlice`, which allocated two intermediate slices per group (context, user, tenant).
- `ToMap`: use the snapshot-owned user/tenant maps directly instead of copying them with `lo.Assign` - `snapshot()` always returns freshly merged maps, so mutating them is safe.
- `formatVerbose`: replace the `Split` -> `lo.Map(prefix)` -> `Join` pipeline for request/response dumps with a single-pass writer into the existing `strings.Builder` (`writePrefixedLines`), preserving output byte-for-byte.
- `writePrefixedLines`: take its input as `[]byte` instead of `string`. Both callers already hold the httputil dump as `[]byte` and were converting it to `string` just for this call; accepting `[]byte` directly removes that copy.

## Benchmarks

`benchstat` vs `main` (darwin/arm64, Apple M3, `-count=10 -cpu=1`):

```
            │ before2.bench.txt │          after2.bench.txt          │
            │      sec/op       │   sec/op     vs base               │
ToMap               3.843µ ± 4%   3.812µ ± 6%       ~ (p=0.393 n=10)
LogValue            3.803µ ± 4%   3.857µ ± 3%       ~ (p=0.353 n=10)
MarshalJSON         5.852µ ± 5%   5.754µ ± 8%       ~ (p=0.353 n=10)
geomean             4.406µ        4.390µ       -0.37%

            │ before2.bench.txt │          after2.bench.txt           │
            │       B/op        │     B/op      vs base               │
ToMap              5.901Ki ± 0%   5.573Ki ± 0%  -5.56% (p=0.000 n=10)
LogValue           5.977Ki ± 0%   5.758Ki ± 0%  -3.66% (p=0.000 n=10)
MarshalJSON        6.665Ki ± 0%   6.665Ki ± 0%       ~ (p=1.000 n=10)
geomean            6.172Ki        5.980Ki       -3.10%

            │ before2.bench.txt │          after2.bench.txt           │
            │     allocs/op     │ allocs/op   vs base                 │
ToMap                72.00 ± 0%   70.00 ± 0%  -2.78% (p=0.000 n=10)
LogValue             70.00 ± 0%   66.00 ± 0%  -5.71% (p=0.000 n=10)
MarshalJSON          92.00 ± 0%   92.00 ± 0%       ~ (p=1.000 n=10)
geomean              77.40        75.19       -2.86%
```

Note: wall-clock deltas were not statistically significant on this run (background noise on the benchmark machine), but the `B/op` and `allocs/op` reductions are fully reproducible (0% variance, p<0.001). `MarshalJSON`'s benchmark fixture does not set User/Tenant data, so it does not exercise the `ToMap` fast path.

For the `writePrefixedLines` `[]byte` change specifically, `benchstat` vs the previous string-based version (same machine, `-count=10 -cpu=1`, ~100-byte dump of typical request headers), measured with a throwaway internal benchmark not included in this PR (existing benchmarks live in the external `benchmarks/` package and `writePrefixedLines` is unexported):

```
                            │ wpl_before.txt │            wpl_after.txt            │
                            │     sec/op     │   sec/op     vs base                │
TempWritePrefixedLinesSmall      149.7n ± 2%   134.5n ± 4%  -10.15% (p=0.001 n=10)

                            │ wpl_before.txt │           wpl_after.txt            │
                            │      B/op      │    B/op     vs base                │
TempWritePrefixedLinesSmall       344.0 ± 0%   232.0 ± 0%  -32.56% (p=0.000 n=10)

                            │ wpl_before.txt │           wpl_after.txt            │
                            │   allocs/op    │ allocs/op   vs base                │
TempWritePrefixedLinesSmall       5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
```

## Test plan

Verified with `go build ./...`, `go vet ./...`, `go test ./...`, and the benchmark runs above compared with `benchstat`.
