### PR TITLE
perf(error): check SourceFragmentsHidden before formatting sources

### DIFF
--- a/error.go
+++ b/error.go
@@ -680,8 +680,13 @@ func (o OopsError) LogValue() slog.Value { //nolint:gocyclo
 		attrs = append(attrs, slog.String("stacktrace", stacktrace))
 	}
 
-	if sources := o.Sources(); sources != "" && !SourceFragmentsHidden {
-		attrs = append(attrs, slog.String("sources", sources))
+	// Check the flag before calling Sources(): formatting source fragments
+	// reads source files from disk and builds the full output string, all of
+	// which would be discarded here when fragments are hidden (the default).
+	if !SourceFragmentsHidden {
+		if sources := o.Sources(); sources != "" {
+			attrs = append(attrs, slog.String("sources", sources))
+		}
 	}
 
 	return slog.GroupValue(attrs...)
@@ -780,8 +785,11 @@ func (o OopsError) ToMap() map[string]any { //nolint:gocyclo
 		payload["stacktrace"] = stacktrace
 	}
 
-	if sources := o.Sources(); sources != "" && !SourceFragmentsHidden {
-		payload["sources"] = sources
+	// See LogValue: only format source fragments when they will be used.
+	if !SourceFragmentsHidden {
+		if sources := o.Sources(); sources != "" {
+			payload["sources"] = sources
+		}
 	}
 
 	return payload
@@ -910,8 +918,11 @@ func (o *OopsError) formatVerbose() string { //nolint:gocyclo
 		_, _ = fmt.Fprintf(&output, "Stacktrace:\n%s\n", stacktrace)
 	}
 
-	if sources := o.Sources(); sources != "" && !SourceFragmentsHidden {
-		_, _ = fmt.Fprintf(&output, "Sources:\n%s\n", sources)
+	// See LogValue: only format source fragments when they will be used.
+	if !SourceFragmentsHidden {
+		if sources := o.Sources(); sources != "" {
+			_, _ = fmt.Fprintf(&output, "Sources:\n%s\n", sources)
+		}
 	}
 
 	return output.String()

--- a/oops_test.go
+++ b/oops_test.go
@@ -1796,8 +1796,10 @@ func TestOopsSourceFragmentsVisible(t *testing.T) { //nolint:paralleltest
 // TestOopsSourceFragmentsHiddenByDefault verifies that ToMap, LogValue and
 // formatVerbose omit "sources" when SourceFragmentsHidden is true (the
 // default), even though the error carries a resolvable stacktrace.
-func TestOopsSourceFragmentsHiddenByDefault(t *testing.T) {
-	t.Parallel()
+//
+// Not parallel: asserts on the SourceFragmentsHidden default, which
+// TestOopsSourceFragmentsVisible flips for its own duration.
+func TestOopsSourceFragmentsHiddenByDefault(t *testing.T) { //nolint:paralleltest
 	is := assert.New(t)
 
 	is.True(SourceFragmentsHidden, "this test assumes the package default")

--- a/oops_test.go
+++ b/oops_test.go
@@ -1756,3 +1756,61 @@ func TestOopsJoinNilHandling(t *testing.T) {
 	result2 := Join(nil, nil)
 	is.NoError(result2)
 }
+
+// TestOopsSourceFragmentsVisible verifies that ToMap, LogValue and
+// formatVerbose include the "sources" entry when SourceFragmentsHidden is
+// false, and that its content matches OopsError.Sources().
+func TestOopsSourceFragmentsVisible(t *testing.T) { //nolint:paralleltest
+	// Modifies the global SourceFragmentsHidden flag — do not run in parallel.
+	is := assert.New(t)
+
+	original := SourceFragmentsHidden
+	SourceFragmentsHidden = false
+	defer func() { SourceFragmentsHidden = original }()
+
+	err := New("boom")
+	oopsErr := err.(OopsError)
+
+	sources := oopsErr.Sources()
+	is.NotEmpty(sources, "Sources() should be non-empty when SourceFragmentsHidden is false")
+
+	m := oopsErr.ToMap()
+	is.Equal(sources, m["sources"])
+
+	group := oopsErr.LogValue().Group()
+	var got string
+	var found bool
+	for _, a := range group {
+		if a.Key == "sources" {
+			found = true
+			got = a.Value.String()
+		}
+	}
+	is.True(found, "expected a 'sources' attr in LogValue when SourceFragmentsHidden is false")
+	is.Equal(sources, got)
+
+	verbose := oopsErr.formatVerbose()
+	is.Contains(verbose, "Sources:\n"+sources)
+}
+
+// TestOopsSourceFragmentsHiddenByDefault verifies that ToMap, LogValue and
+// formatVerbose omit "sources" when SourceFragmentsHidden is true (the
+// default), even though the error carries a resolvable stacktrace.
+func TestOopsSourceFragmentsHiddenByDefault(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.True(SourceFragmentsHidden, "this test assumes the package default")
+
+	err := New("boom")
+	oopsErr := err.(OopsError)
+
+	_, hasSources := oopsErr.ToMap()["sources"]
+	is.False(hasSources)
+
+	for _, a := range oopsErr.LogValue().Group() {
+		is.NotEqual("sources", a.Key)
+	}
+
+	is.NotContains(oopsErr.formatVerbose(), "Sources:")
+}

--- a/sources.go
+++ b/sources.go
@@ -1,8 +1,8 @@
 package oops
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -166,8 +166,7 @@ func getSourceFromFrame(frame oopsStacktraceFrame) []string {
 
 		line := lines[i]
 
-		// Format the line with line number
-		message := fmt.Sprintf("%d\t%s", i+1, line)
+		message := strconv.Itoa(i+1) + "\t" + line
 		output = append(output, message)
 
 		// Add visual indicator for the error line

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -1,7 +1,6 @@
 package oops
 
 import (
-	"fmt"
 	"reflect"
 	"runtime"
 	"slices"
@@ -386,10 +385,7 @@ func framesToStacktraceBlocks(blocks []outputBlock) []string {
 			firstFrame = false
 		}
 
-		stacktraceStr := strings.Join(frameLines, "\n")
-		block := fmt.Sprintf("%s\n%s", msg, stacktraceStr)
-
-		output = append(output, block)
+		output = append(output, msg+"\n"+strings.Join(frameLines, "\n"))
 	}
 
 	slices.Reverse(output)
@@ -404,7 +400,7 @@ func framesToSourceBlocks(blocks []outputBlock) []string {
 		header, body := st.Source()
 
 		if b.msg != "" {
-			header = fmt.Sprintf("%s\n%s", b.msg, header)
+			header = b.msg + "\n" + header
 		}
 
 		if header != "" && len(body) > 0 {

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -176,6 +176,98 @@ func TestOopsStacktraceString(t *testing.T) {
 	}
 }
 
+func TestOopsStacktraceSource(t *testing.T) {
+	t.Parallel()
+
+	_, currentFile, currentLine, _ := runtime.Caller(0)
+
+	t.Run("empty_frames", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		st := &oopsStacktrace{span: "test"}
+		header, body := st.Source()
+		is.Empty(header)
+		is.Empty(body)
+	})
+
+	t.Run("with_frames", func(t *testing.T) { //nolint:paralleltest
+		t.Cleanup(func() {
+			mutex.Lock()
+			cache = map[string][]string{}
+			mutex.Unlock()
+		})
+		is := assert.New(t)
+
+		frame := oopsStacktraceFrame{file: currentFile, line: currentLine, function: "TestOopsStacktraceSource"}
+		st := &oopsStacktrace{span: "test", frames: []oopsStacktraceFrame{frame}}
+
+		header, body := st.Source()
+		is.Equal(frame.String(), header)
+		is.NotEmpty(body)
+	})
+}
+
+func TestFramesToSourceBlocks(t *testing.T) {
+	t.Parallel()
+
+	_, currentFile, currentLine, _ := runtime.Caller(0)
+
+	t.Run("no_blocks", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		is.Empty(framesToSourceBlocks(nil))
+	})
+
+	t.Run("message_and_frames_produce_a_block", func(t *testing.T) { //nolint:paralleltest
+		t.Cleanup(func() {
+			mutex.Lock()
+			cache = map[string][]string{}
+			mutex.Unlock()
+		})
+		is := assert.New(t)
+
+		frame := oopsStacktraceFrame{file: currentFile, line: currentLine, function: "TestFramesToSourceBlocks"}
+		blocks := []outputBlock{{msg: "boom", frames: []oopsStacktraceFrame{frame}}}
+
+		out := framesToSourceBlocks(blocks)
+		is.Len(out, 1)
+		is.Contains(out[0], "boom")
+		is.Contains(out[0], frame.String())
+	})
+
+	t.Run("unresolvable_frame_produces_no_block", func(t *testing.T) {
+		t.Parallel()
+		is := assert.New(t)
+
+		frame := oopsStacktraceFrame{file: "/nonexistent/path/file.go", line: 1, function: "x"}
+		blocks := []outputBlock{{msg: "boom", frames: []oopsStacktraceFrame{frame}}}
+
+		is.Empty(framesToSourceBlocks(blocks))
+	})
+
+	t.Run("multiple_blocks_are_reversed", func(t *testing.T) { //nolint:paralleltest
+		t.Cleanup(func() {
+			mutex.Lock()
+			cache = map[string][]string{}
+			mutex.Unlock()
+		})
+		is := assert.New(t)
+
+		frame := oopsStacktraceFrame{file: currentFile, line: currentLine, function: "TestFramesToSourceBlocks"}
+		blocks := []outputBlock{
+			{msg: "first", frames: []oopsStacktraceFrame{frame}},
+			{msg: "second", frames: []oopsStacktraceFrame{frame}},
+		}
+
+		out := framesToSourceBlocks(blocks)
+		is.Len(out, 2)
+		is.Contains(out[0], "second")
+		is.Contains(out[1], "first")
+	})
+}
+
 func TestOopsStacktraceFrameString(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `ToMap`, `LogValue` and `formatVerbose` evaluated `if sources := o.Sources(); sources != "" && !SourceFragmentsHidden` left-to-right: `Sources()` formatted the full source-fragment output - reading source files from disk and building per-line strings - and the result was then discarded, because `SourceFragmentsHidden` is `true` by default. Checking the flag first skips all of that work in the default configuration; behavior with `SourceFragmentsHidden=false` is unchanged.
- Also replaces `fmt.Sprintf` with direct concatenation in the per-line / per-block builders (`getSourceFromFrame`, `framesToStacktraceBlocks`, `framesToSourceBlocks`), benefiting the non-hidden path too.

## Benchmarks

`benchstat` vs `main` (darwin/arm64, Apple M3, `-count=10 -cpu=1`):

```
         │ before3.txt │              after3.txt              │
         │   sec/op    │    sec/op     vs base                │
ToMap      3.494µ ± 5%   1.631µ ± 15%  -53.31% (p=0.002 n=10)
LogValue   3.499µ ± 4%   1.478µ ±  8%  -57.77% (p=0.000 n=10)
geomean    3.496µ        1.553µ        -55.60%

         │ before3.txt  │              after3.txt              │
         │     B/op     │     B/op      vs base                │
ToMap      5.214Ki ± 0%   2.789Ki ± 0%  -46.51% (p=0.000 n=10)
LogValue   5.357Ki ± 0%   2.745Ki ± 0%  -48.76% (p=0.000 n=10)
geomean    5.285Ki        2.767Ki       -47.65%

         │ before3.txt │             after3.txt             │
         │  allocs/op  │ allocs/op   vs base                │
ToMap       63.00 ± 0%   28.00 ± 0%  -55.56% (p=0.000 n=10)
LogValue    61.00 ± 0%   24.00 ± 0%  -60.66% (p=0.000 n=10)
geomean     61.99        25.92       -58.18%
```

`BenchmarkNewStacktrace` was also checked as a control (this path never calls `Sources()`): allocations and memory are byte-for-byte identical before/after (0% variance), confirming the change is isolated to the `Sources()`-gated paths.

## Test coverage

The `SourceFragmentsHidden=false` path (and, by extension, `oopsStacktrace.Source()` and `framesToSourceBlocks`) had no coverage at all before this PR — every existing test ran with the package default (`true`), so the new gated branches and the two previously-0%-covered functions were untested. Added:

- `TestOopsSourceFragmentsVisible` / `TestOopsSourceFragmentsHiddenByDefault`: assert `ToMap`, `LogValue` and `formatVerbose` include/omit `"sources"` depending on the flag. Both run sequentially (no `t.Parallel()`, `//nolint:paralleltest`) since the former temporarily flips the package-level flag and the latter asserts on its default.
- `TestOopsStacktraceSource`: direct coverage of `oopsStacktrace.Source()` (empty-frames and with-frames cases).
- `TestFramesToSourceBlocks`: direct coverage of `framesToSourceBlocks`, including the no-body-skips-block and multi-block-reversal cases.

Package coverage: 90.8% -> 94.0%. `Source` and `framesToSourceBlocks` are now at 100%.

## Test plan

Verified with `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues), and `go test -bench=BenchmarkToMap -bench=BenchmarkLogValue -benchmem -count=10 -cpu=1 ./benchmarks` run before/after the change and compared with `benchstat`.
