### PR TITLE
chore(deps): add cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,29 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directory: /
     schedule:
       interval: monthly
   - package-ecosystem: gomod
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     directory: /
     schedule:
       interval: monthly
   - package-ecosystem: gomod
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     directory: /recovery/**
     schedule:
       interval: monthly
   - package-ecosystem: gomod
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     directory: /loggers/**
     schedule:
       interval: monthly


### PR DESCRIPTION
Adds `cooldown` to each Dependabot update entry to avoid PR spam from freshly published versions.

- `default-days: 7` for all ecosystems
- `semver-major-days: 30` for ecosystems that support semver overrides

Security updates bypass the cooldown.